### PR TITLE
Add backend tests for tick and bar APIs

### DIFF
--- a/backend/django/app/nexus/tests.py
+++ b/backend/django/app/nexus/tests.py
@@ -1,3 +1,27 @@
-from django.test import TestCase
+from rest_framework.test import APIClient, APITestCase
+from rest_framework.response import Response
+from unittest.mock import patch
 
-# Create your tests here.
+
+class TickBarAPITests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    @patch('app.nexus.views.TickViewSet.list')
+    def test_get_ticks(self, mock_list):
+        sample = [{'symbol': 'EURUSD', 'bid': 1.1}, {'symbol': 'EURUSD', 'bid': 1.11}]
+        mock_list.return_value = Response(sample)
+        response = self.client.get('/v1/ticks/?symbol=EURUSD')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), sample)
+
+    @patch('app.nexus.views.BarViewSet.list')
+    def test_get_bars(self, mock_list):
+        sample = [
+            {'symbol': 'EURUSD', 'timeframe': 'M1', 'open': 1.0},
+            {'symbol': 'EURUSD', 'timeframe': 'M1', 'open': 1.1},
+        ]
+        mock_list.return_value = Response(sample)
+        response = self.client.get('/v1/bars/?symbol=EURUSD&timeframe=M1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), sample)

--- a/backend/django/app/test_settings.py
+++ b/backend/django/app/test_settings.py
@@ -1,0 +1,14 @@
+from .settings import *
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
+
+CELERY_BROKER_URL = 'memory://'
+CELERY_RESULT_BACKEND = 'cache+memory://'
+LOGGING = {"version": 1, "disable_existing_loggers": True}

--- a/backend/mt5/app/tests/test_routes.py
+++ b/backend/mt5/app/tests/test_routes.py
@@ -1,0 +1,57 @@
+import types
+import sys
+import os
+
+class DummyMT5(types.ModuleType):
+    def __getattr__(self, name):
+        return 0
+
+sys.modules['MetaTrader5'] = DummyMT5('MetaTrader5')
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import json
+import pytest
+
+from app import app
+from routes import data
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_get_ticks(client, monkeypatch):
+    sample = [
+        {'time': 1000, 'bid': 1.1, 'ask': 1.2, 'last': 1.15, 'volume': 10},
+        {'time': 1001, 'bid': 1.11, 'ask': 1.21, 'last': 1.16, 'volume': 12},
+    ]
+
+    def fake_copy_ticks_from(symbol, start, limit, flag):
+        return sample
+
+    monkeypatch.setattr(data.mt5, 'copy_ticks_from', fake_copy_ticks_from)
+
+    resp = client.get('/ticks?symbol=EURUSD&limit=2')
+    assert resp.status_code == 200
+    data_resp = resp.get_json()
+    assert len(data_resp) == 2
+    assert data_resp[0]['bid'] == 1.1
+
+def test_get_bars(client, monkeypatch):
+    sample = [
+        {'time': 1000, 'open': 1.0, 'high': 1.2, 'low': 0.9, 'close': 1.1, 'tick_volume': 10, 'spread': 2, 'real_volume': 15},
+        {'time': 1001, 'open': 1.1, 'high': 1.3, 'low': 1.0, 'close': 1.2, 'tick_volume': 12, 'spread': 2, 'real_volume': 16},
+    ]
+
+    def fake_copy_rates_from_pos(symbol, timeframe, pos, limit):
+        return sample
+
+    monkeypatch.setattr(data.mt5, 'copy_rates_from_pos', fake_copy_rates_from_pos)
+    monkeypatch.setattr(data, 'get_timeframe', lambda tf: 1)
+
+    resp = client.get('/bars/EURUSD/M1?limit=2')
+    assert resp.status_code == 200
+    data_resp = resp.get_json()
+    assert len(data_resp) == 2
+    assert data_resp[0]['open'] == 1.0


### PR DESCRIPTION
## Summary
- add SQLite-based Django settings for testing
- mock view methods to test Django /ticks and /bars routes
- add pytest suite for Flask tick/bar endpoints with MT5 stubs

## Testing
- `python backend/django/manage.py test app.nexus --settings=app.test_settings -v 2`
- `pytest backend/mt5/app/tests/test_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_b_687c1fb67098832e9f7a6f2f7a669c1f