### PR TITLE
Standardize Django API prefix

### DIFF
--- a/.env
+++ b/.env
@@ -19,6 +19,7 @@ POSTGRES_PASSWORD=1234
 # Backend - Django
 MT5_API_URL=http://mt5:5001
 DJANGO_API_URL=http://django:8000
+DJANGO_API_PREFIX=/api/v1
 DJANGO_DOMAIN=django3.zanalytics.app
 
 # Celery

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This modular design facilitates secure separation of concerns, easy extensibilit
 - `ACME_EMAIL`: Email address for Let's Encrypt notifications.
 - `MT5_API_URL`: Base URL where the MT5 service is available (e.g., `http://mt5:5001`).
 - `DJANGO_API_URL`: Base URL of the Django API service (e.g., `http://django:8000`).
+- `DJANGO_API_PREFIX`: Path prefix for all Django API endpoints (default `/api/v1`).
 - `DJANGO_SECRET_KEY`: Secret key for the Django application. **Required.**
 >>>>>>> c859abdafe2b06c03292270351066a2041e1452c
 
@@ -236,6 +237,7 @@ PASSWORD=super_secret_password
 # MT5 and API endpoints
 MT5_API_URL=http://mt5-api:8050
 DJANGO_API_URL=http://django-api:8000
+DJANGO_API_PREFIX=/api/v1
 
 # Database config
 POSTGRES_HOST=postgres

--- a/api_integration/api_integration_guide.md
+++ b/api_integration/api_integration_guide.md
@@ -146,7 +146,7 @@ If you're having trouble connecting to the API:
 
 1. Check that the Django server is running
 2. Verify the API URL is correct in your environment variables
-3. Test the `/api/ping/` endpoint to make sure the server responds with `{ "status": "ok" }`
+3. Test the `/api/v1/ping/` endpoint to make sure the server responds with `{ "status": "ok" }`
 4. Check for any network issues or firewalls blocking the connection
 5. Look at the Django server logs for any errors
 

--- a/api_integration/django_api_client.py
+++ b/api_integration/django_api_client.py
@@ -77,7 +77,7 @@ class DjangoAPIClient:
     def _test_connection(self) -> bool:
         """Test the connection to the API."""
         try:
-            url = f"{self.base_url}/api/ping/"
+            url = f"{self.base_url}{self.api_prefix}/ping/"
             response = self.session.get(url, timeout=self.timeout)
             return response.status_code == 200
         except Exception as e:

--- a/backend/django/app/nexus/tests.py
+++ b/backend/django/app/nexus/tests.py
@@ -11,7 +11,7 @@ class TickBarAPITests(APITestCase):
     def test_get_ticks(self, mock_list):
         sample = [{'symbol': 'EURUSD', 'bid': 1.1}, {'symbol': 'EURUSD', 'bid': 1.11}]
         mock_list.return_value = Response(sample)
-        response = self.client.get('/v1/ticks/?symbol=EURUSD')
+        response = self.client.get('/api/v1/ticks/?symbol=EURUSD')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), sample)
 
@@ -22,6 +22,6 @@ class TickBarAPITests(APITestCase):
             {'symbol': 'EURUSD', 'timeframe': 'M1', 'open': 1.1},
         ]
         mock_list.return_value = Response(sample)
-        response = self.client.get('/v1/bars/?symbol=EURUSD&timeframe=M1')
+        response = self.client.get('/api/v1/bars/?symbol=EURUSD&timeframe=M1')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), sample)

--- a/backend/django/app/urls.py
+++ b/backend/django/app/urls.py
@@ -4,6 +4,6 @@ from app.nexus.views import PingView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/ping/', PingView.as_view(), name='api-ping'),
-    path('v1/', include('app.nexus.urls')),
+    path('api/v1/ping/', PingView.as_view(), name='api-ping'),
+    path('api/v1/', include('app.nexus.urls')),
 ]

--- a/backend/mt5/.env.example
+++ b/backend/mt5/.env.example
@@ -19,6 +19,7 @@ POSTGRES_PASSWORD=changeme
 # Backend - Django
 MT5_API_URL=http://mt5:5001
 DJANGO_API_URL=http://django:8000
+DJANGO_API_PREFIX=/api/v1
 DJANGO_DOMAIN=django.example.com
 
 # Celery


### PR DESCRIPTION
## Summary
- use `/api/v1` prefix for all Django routes
- adjust API client ping check
- update unit tests
- document DJANGO_API_PREFIX and add to `.env` files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688010e58574832e95421ff5dcb0e2d2