### PR TITLE
Add DJANGO_SECRET_KEY default

### DIFF
--- a/backend/django/app/test_settings.py
+++ b/backend/django/app/test_settings.py
@@ -2,6 +2,8 @@ import sys, types
 pandas_stub = types.ModuleType('pandas')
 setattr(pandas_stub, 'DataFrame', object)
 sys.modules.setdefault('pandas', pandas_stub)
+import os
+os.environ.setdefault("DJANGO_SECRET_KEY", "test-secret")
 from .settings import *
 
 DATABASES = {


### PR DESCRIPTION
## Summary
- set a default `DJANGO_SECRET_KEY` in `backend/django/app/test_settings.py`

## Testing
- `python -m compileall backend/django/app/test_settings.py`


------
https://chatgpt.com/codex/tasks/task_b_688148487030832ebea8b11efaa8a5cf