### PR TITLE
Add time range filters for bars and ticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ This approach improves both data quality and system efficiency, ensuring that da
     ```bash
     curl "$DJANGO_API_URL/api/v1/enriched/?symbol=USDJPY"
     ```
+- Filter ticks or bars by time range using the Django API:
+    ```bash
+    curl "$DJANGO_API_URL/api/v1/ticks/?symbol=EURUSD&time_after=2024-01-01T00:00:00Z&time_before=2024-01-01T12:00:00Z"
+    curl "$DJANGO_API_URL/api/v1/bars/?symbol=EURUSD&timeframe=M5&time_after=2024-01-01T00:00:00Z"
+    ```
 
 ### d) **Troubleshooting**
 - Dashboard blank?  

--- a/backend/django/app/nexus/filters.py
+++ b/backend/django/app/nexus/filters.py
@@ -1,5 +1,6 @@
 from django_filters import rest_framework as filters
-from .models import Trade
+from .models import Trade, Tick, Bar
+
 
 class TradeFilter(filters.FilterSet):
     # Time range filters
@@ -7,20 +8,20 @@ class TradeFilter(filters.FilterSet):
     entry_time_before = filters.DateTimeFilter(field_name='entry_time', lookup_expr='lte')
     close_time_after = filters.DateTimeFilter(field_name='close_time', lookup_expr='gte')
     close_time_before = filters.DateTimeFilter(field_name='close_time', lookup_expr='lte')
-    
+
     # Numeric range filters
     pnl_min = filters.NumberFilter(field_name='pnl', lookup_expr='gte')
     pnl_max = filters.NumberFilter(field_name='pnl', lookup_expr='lte')
     position_size_min = filters.NumberFilter(field_name='position_size_usd', lookup_expr='gte')
     position_size_max = filters.NumberFilter(field_name='position_size_usd', lookup_expr='lte')
-    
+
     # Symbol filters
     symbol = filters.CharFilter(lookup_expr='iexact')
     symbols = filters.BaseInFilter(field_name='symbol', lookup_expr='in')
-    
+
     # Trade type filter
     type = filters.CharFilter(lookup_expr='iexact')
-    
+
     # Status filters
     is_open = filters.BooleanFilter(field_name='close_time', lookup_expr='isnull')
 
@@ -32,3 +33,22 @@ class TradeFilter(filters.FilterSet):
             'max_profit': ['gte', 'lte'],
             'closing_reason': ['exact', 'icontains'],
         }
+
+
+class TickFilter(filters.FilterSet):
+    time_after = filters.DateTimeFilter(field_name='time', lookup_expr='gte')
+    time_before = filters.DateTimeFilter(field_name='time', lookup_expr='lte')
+
+    class Meta:
+        model = Tick
+        fields = ['symbol']
+
+
+class BarFilter(filters.FilterSet):
+    time_after = filters.DateTimeFilter(field_name='time', lookup_expr='gte')
+    time_before = filters.DateTimeFilter(field_name='time', lookup_expr='lte')
+
+    class Meta:
+        model = Bar
+        fields = ['symbol', 'timeframe']
+

--- a/backend/django/app/nexus/views.py
+++ b/backend/django/app/nexus/views.py
@@ -8,7 +8,7 @@ from .serializers import (
     TickSerializer,
     BarSerializer,
 )
-from .filters import TradeFilter
+from .filters import TradeFilter, TickFilter, BarFilter
 
 from app.utils.api.order import send_market_order, modify_sl_tp
 
@@ -117,14 +117,14 @@ class ModifySLTPView(views.APIView):
 class TickViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Tick.objects.all()
     serializer_class = TickSerializer
-    filterset_fields = ["symbol"]
+    filterset_class = TickFilter
     ordering = ["-time"]
 
 
 class BarViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Bar.objects.all()
     serializer_class = BarSerializer
-    filterset_fields = ["symbol", "timeframe"]
+    filterset_class = BarFilter
     ordering = ["-time"]
 
 
@@ -162,3 +162,4 @@ class TimeframeListView(views.APIView):
                 .order_by("timeframe")
             )
         return Response({"timeframes": list(timeframes)})
+


### PR DESCRIPTION
## Summary
- introduce `TickFilter` and `BarFilter`
- switch viewsets to use custom filter classes
- document new time range query parameters

## Testing
- `python manage.py test` *(fails: could not translate host name "postgres" to address)*

------
https://chatgpt.com/codex/tasks/task_b_688149b54648832e87ae0efb11e0cba0