### PR TITLE
Add tick data resampling helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ A typical enrichment workflow begins with raw tick data streamed from MT5 or loa
 1. **Transformation:** The raw tick is parsed and normalized (e.g., timestamp conversion, price adjustments).
 2. **Hashing:** The tick is hashed with MD5 to detect duplicates.
 3. **Storage:** Unique ticks are inserted into Postgres for long-term storage and cached in Redis for fast access.
-4. **Feature Generation:** Rolling statistics, indicators (such as SMA, RSI), and signals are computed over the tick and bar data.
+4. **Feature Generation:** Ticks are resampled into OHLC bars using `pandas.resample` and rolling statistics or indicators (SMA, RSI, etc.) are computed over the resulting bar data.
 5. **Caching:** Computed features are cached in Redis to support low-latency dashboard queries.
 6. **Visualization:** The Streamlit dashboard fetches enriched data from the Django API, which queries both Postgres and Redis, to render charts and analytics in near real-time.
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from .enrichment import enrich_ticks
+from .enrichment import enrich_ticks, aggregate_ticks_to_bars
 
-__all__ = ["enrich_ticks"]
+__all__ = ["enrich_ticks", "aggregate_ticks_to_bars"]


### PR DESCRIPTION
## Summary
- convert tick DataFrame into OHLC bars via pandas in `utils/enrichment`
- re-export new helper in `utils/__init__`
- document resampling step in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_688151ba0330832ebe30c066eae01e87