### PR TITLE
feat: add weekly Wyckoff calibration workflow

### DIFF
--- a/.github/workflows/wyckoff_calibration.yml
+++ b/.github/workflows/wyckoff_calibration.yml
@@ -1,0 +1,30 @@
+name: Wyckoff Calibration
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  calibrate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas numpy pyyaml
+      - name: Run calibration
+        env:
+          DATA_PATH: ${{ secrets.WYCKOFF_CALIBRATION_DATA }}
+        run: |
+          python utils/wyckoff_calibration.py --data "$DATA_PATH" --config pulse_config.yaml --threshold 0.01
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update Wyckoff weights'
+          file_pattern: pulse_config.yaml


### PR DESCRIPTION
## Summary
- add CLI utility to tune Wyckoff weights and update pulse_config.yaml when scores improve
- schedule weekly GitHub Action to run calibration and auto-commit weight updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ba260bf07c83289b302bf8d03c9e62