### PR TITLE
Integrate adaptive Wyckoff scorer into confluence scoring

### DIFF
--- a/components/wyckoff_scorer.py
+++ b/components/wyckoff_scorer.py
@@ -26,6 +26,7 @@ class WyckoffScorer:
         return {
             "wyckoff_score": float(total),
             "wyckoff_probs": probs,
+            "phase_labels": analysis["phases"]["labels"],
             "events": analysis["events"],
             "explain": analysis["events_reasons"],
             "news_mask": analysis.get("news_mask"),


### PR DESCRIPTION
## Summary
- use adaptive `WyckoffScorer` in `ConfluenceScorer`
- expose phase labels from adaptive Wyckoff analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ba28765f888328845004bdd4c995af