### PR TITLE
Add pulse integration plan

### DIFF
--- a/PULSE_INTEGRATION_PLAN.md
+++ b/PULSE_INTEGRATION_PLAN.md
@@ -1,0 +1,558 @@
+# 🎯 Zanalytics Pulse - Integration Checklist & Implementation Plan
+
+## 1. **Wire Up Existing Analyzers** (Priority: HIGH)
+
+The Pulse components currently use placeholder methods. These need to be connected to your actual analyzers:
+
+### File: `confluence_scorer.py`
+```python
+# Update imports at the top
+from components.smc_analyser import SMCAnalyzer
+from components.wyckoff_analyzer import WyckoffAnalyzer
+from components.technical_analysis import TechnicalAnalysis
+
+# In __init__ method, replace placeholders:
+def __init__(self, config_path: str = "pulse_config.yaml"):
+    # ... existing code ...
+    
+    # Initialize actual analyzers
+    self.smc = SMCAnalyzer()
+    self.wyckoff = WyckoffAnalyzer()
+    self.technical = TechnicalAnalysis()
+
+# Update detection methods to use real analyzers:
+def _calculate_smc_score(self, data: Dict) -> float:
+    # Replace simplified logic with:
+    smc_result = self.smc.analyze(data)
+    return self._normalize_smc_score(smc_result)
+
+def _calculate_wyckoff_score(self, data: Dict) -> float:
+    # Replace simplified logic with:
+    wyckoff_result = self.wyckoff.analyze(data)
+    return self._normalize_wyckoff_score(wyckoff_result)
+
+def _calculate_technical_score(self, data: Dict) -> float:
+    # Replace simplified logic with:
+    tech_result = self.technical.calculate_all(data)
+    return self._normalize_technical_score(tech_result)
+```
+
+## 2. Django API Integration (Priority: HIGH)
+
+Create Django views and URLs for Pulse endpoints:
+
+### File: `backend/django/app/pulse_views.py` (NEW)
+```python
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from pulse_kernel import PulseKernel
+import json
+
+# Initialize kernel (singleton pattern recommended)
+_pulse_kernel = None
+
+def get_pulse_kernel():
+    global _pulse_kernel
+    if _pulse_kernel is None:
+        _pulse_kernel = PulseKernel("pulse_config.yaml")
+    return _pulse_kernel
+
+@api_view(['GET'])
+def health_check(request):
+    """Pulse system health check"""
+    kernel = get_pulse_kernel()
+    report = kernel.get_session_report()
+    return Response({
+        'status': 'healthy',
+        'version': '11.5.1',
+        'behavioral_health': report['behavioral_health'],
+        'active_signals': len(report['active_signals'])
+    })
+
+@api_view(['POST'])
+def get_confluence_score(request):
+    """Calculate confluence score for market data"""
+    data = request.data
+    kernel = get_pulse_kernel()
+    
+    # Process through confluence scorer
+    result = kernel.confluence_scorer.score(data)
+    return Response(result)
+
+@api_view(['GET'])
+def get_risk_status(request):
+    """Get current risk enforcement status"""
+    kernel = get_pulse_kernel()
+    behavioral_report = kernel.risk_enforcer.get_behavioral_report()
+    return Response(behavioral_report)
+
+@api_view(['GET'])
+def get_active_signals(request):
+    """Get all active trading signals"""
+    kernel = get_pulse_kernel()
+    return Response(kernel.active_signals)
+
+@api_view(['POST'])
+def process_tick(request):
+    """Process incoming tick through Pulse pipeline"""
+    tick_data = request.data
+    kernel = get_pulse_kernel()
+    
+    signal = kernel.process_frame(tick_data)
+    if signal:
+        return Response({
+            'signal_generated': True,
+            'symbol': signal.symbol,
+            'confluence_score': signal.confluence_score,
+            'entry_price': signal.entry_price,
+            'reasoning': signal.reasoning
+        })
+    return Response({'signal_generated': False})
+```
+
+### File: `backend/django/app/urls.py` (UPDATE)
+```python
+# Add to existing urlpatterns
+from . import pulse_views
+
+urlpatterns += [
+    path('api/pulse/health/', pulse_views.health_check, name='pulse_health'),
+    path('api/pulse/score/', pulse_views.get_confluence_score, name='pulse_score'),
+    path('api/pulse/risk/', pulse_views.get_risk_status, name='pulse_risk'),
+    path('api/pulse/signals/', pulse_views.get_active_signals, name='pulse_signals'),
+    path('api/pulse/process/', pulse_views.process_tick, name='pulse_process'),
+]
+```
+
+## 3. Streamlit Dashboard Integration (Priority: MEDIUM)
+
+Add Pulse UI components to the existing dashboard:
+
+### File: `dashboard/pages/pulse_dashboard.py` (NEW)
+```python
+import streamlit as st
+import requests
+import pandas as pd
+import plotly.graph_objects as go
+from datetime import datetime, timedelta
+import json
+
+st.set_page_config(page_title="Pulse Behavioral Trading", layout="wide")
+
+# API configuration
+DJANGO_API_URL = st.secrets.get("DJANGO_API_URL", "http://localhost:8000")
+
+def fetch_pulse_health():
+    """Fetch Pulse system health"""
+    response = requests.get(f"{DJANGO_API_URL}/api/pulse/health/")
+    return response.json() if response.ok else None
+
+def fetch_risk_status():
+    """Fetch current risk status"""
+    response = requests.get(f"{DJANGO_API_URL}/api/pulse/risk/")
+    return response.json() if response.ok else None
+
+def fetch_active_signals():
+    """Fetch active trading signals"""
+    response = requests.get(f"{DJANGO_API_URL}/api/pulse/signals/")
+    return response.json() if response.ok else None
+
+# Main dashboard
+st.title("🎯 Zanalytics Pulse - Behavioral Trading System")
+
+# Create layout
+col1, col2, col3 = st.columns([1, 2, 1])
+
+# Health Status Panel
+with col1:
+    st.subheader("📊 System Health")
+    health = fetch_pulse_health()
+    if health:
+        st.metric("Status", health['status'].upper())
+        st.metric("Active Signals", health['active_signals'])
+        
+        # Behavioral health indicators
+        bh = health['behavioral_health']
+        if bh.get('overtrading_risk'):
+            st.warning("⚠️ Overtrading Risk Detected")
+        if bh.get('cooling_off_active'):
+            st.info("❄️ Cooling-off Period Active")
+        if not bh.get('daily_loss_safe'):
+            st.error("🚨 Daily Loss Limit Approaching")
+
+# Risk Status Panel
+with col3:
+    st.subheader("🛡️ Risk Protection")
+    risk = fetch_risk_status()
+    if risk:
+        state = risk['current_state']
+        
+        # Display key metrics
+        st.metric("Confidence Level", f"{state['confidence_level']:.0%}")
+        st.metric("Daily P&L", f"{state['daily_pnl_percent']:.2%}")
+        st.metric("Trades Today", state['trades_today'])
+        
+        # Emotional state indicator
+        emotional_state = state['emotional_state']
+        if emotional_state == 'neutral':
+            st.success(f"😊 Emotional State: {emotional_state}")
+        elif emotional_state == 'confident':
+            st.info(f"💪 Emotional State: {emotional_state}")
+        else:
+            st.warning(f"😰 Emotional State: {emotional_state}")
+        
+        # Recommendations
+        if risk.get('recommendations'):
+            st.subheader("💡 Recommendations")
+            for rec in risk['recommendations']:
+                st.write(f"• {rec}")
+
+# Main Signal Display
+with col2:
+    st.subheader("📈 Active Trading Signals")
+    
+    signals = fetch_active_signals()
+    if signals:
+        for symbol, signal in signals.items():
+            with st.expander(f"{symbol} - Score: {signal['confluence_score']:.1f}%"):
+                col_a, col_b = st.columns(2)
+                with col_a:
+                    st.write(f"**Entry:** {signal['entry_price']}")
+                    st.write(f"**Stop Loss:** {signal['stop_loss']}")
+                    st.write(f"**Take Profit:** {signal['take_profit']}")
+                with col_b:
+                    st.write(f"**Position Size:** {signal['position_size']:.2%}")
+                    st.write(f"**Time:** {signal['timestamp']}")
+                st.write(f"**Reasoning:** {signal['reasoning']}")
+    else:
+        st.info("No active signals at the moment")
+
+# Auto-refresh
+if st.button("🔄 Refresh"):
+    st.rerun()
+
+# Auto-refresh every 5 seconds
+st.markdown(
+    """
+    <script>
+    setTimeout(function(){
+        window.location.reload();
+    }, 5000);
+    </script>
+    """,
+    unsafe_allow_html=True
+)
+```
+
+## 4. Multi-Timeframe (MTF) Integration (Priority: MEDIUM)
+
+Add MTF support as mentioned in your evaluation:
+
+### File: `utils/mtf_resolver.py` (NEW)
+```python
+"""Multi-Timeframe Conflict Resolution"""
+
+class MultiTFResolver:
+    """Resolve conflicts between different timeframe signals"""
+    
+    def __init__(self):
+        self.tf_weights = {
+            'M1': 0.1,   # Noise filter
+            'M5': 0.2,   # Entry timing
+            'M15': 0.3,  # Trend confirmation
+            'H1': 0.25,  # Structure
+            'H4': 0.15   # Major trend
+        }
+    
+    def resolve_conflicts(self, tf_scores: Dict[str, float]) -> Dict:
+        """Resolve multi-timeframe conflicts"""
+        
+        # Calculate weighted score
+        weighted_score = sum(
+            score * self.tf_weights.get(tf, 0.1) 
+            for tf, score in tf_scores.items()
+        )
+        
+        # Check for major conflicts
+        scores = list(tf_scores.values())
+        if max(scores) - min(scores) > 40:  # High divergence
+            return {
+                'score': weighted_score * 0.9,  # Apply penalty
+                'conflict': True,
+                'reason': 'Timeframe divergence detected'
+            }
+        
+        return {
+            'score': weighted_score,
+            'conflict': False,
+            'alignment': 'Good MTF alignment'
+        }
+```
+
+## 5. News Buffer Integration (Priority: LOW)
+
+Add news event awareness:
+
+### File: `utils/news_buffer.py` (NEW)
+```python
+"""News Event Buffer for Volatility Protection"""
+
+import requests
+from datetime import datetime, timedelta
+from typing import List, Dict
+
+class NewsBuffer:
+    """Buffer trading around high-impact news events"""
+    
+    def __init__(self, api_key: str = None):
+        self.api_key = api_key
+        self.buffer_minutes = 30  # Default buffer around news
+        self.high_impact_events = []
+        
+    def fetch_calendar(self) -> List[Dict]:
+        """Fetch economic calendar (implement with your preferred API)"""
+        # Example: ForexFactory, Investing.com, or FRED API
+        pass
+    
+    def is_news_buffer_active(self, timestamp: datetime) -> bool:
+        """Check if we're in a news buffer period"""
+        for event in self.high_impact_events:
+            event_time = event['datetime']
+            buffer_start = event_time - timedelta(minutes=self.buffer_minutes)
+            buffer_end = event_time + timedelta(minutes=self.buffer_minutes)
+            
+            if buffer_start <= timestamp <= buffer_end:
+                return True
+        return False
+    
+    def get_buffer_reason(self, timestamp: datetime) -> str:
+        """Get reason for news buffer"""
+        for event in self.high_impact_events:
+            event_time = event['datetime']
+            buffer_start = event_time - timedelta(minutes=self.buffer_minutes)
+            buffer_end = event_time + timedelta(minutes=self.buffer_minutes)
+            
+            if buffer_start <= timestamp <= buffer_end:
+                return f"News buffer: {event['title']} at {event_time}"
+        return ""
+```
+
+## 6. Testing & Validation (Priority: HIGH)
+
+### File: `tests/test_pulse_integration.py` (UPDATE)
+```python
+import pytest
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from pulse_kernel import PulseKernel
+from confluence_scorer import ConfluenceScorer
+from risk_enforcer import RiskEnforcer
+from datetime import datetime
+
+@pytest.fixture
+def sample_market_data():
+    """Fixture for test market data"""
+    return {
+        'symbol': 'EURUSD',
+        'timeframe': 'H1',
+        'timestamp': datetime.now(),
+        'open': 1.0850,
+        'high': 1.0875,
+        'low': 1.0845,
+        'close': 1.0865,
+        'volume': 1250,
+        'atr': 0.0015,
+        'rsi': 58,
+        'macd': 0.0003,
+        'macd_signal': 0.0002,
+        'ema_20': 1.0855,
+        'ema_50': 1.0845,
+        'trend': 'up'
+    }
+
+@pytest.mark.integration
+def test_confluence_scorer(sample_market_data):
+    """Test confluence scoring"""
+    scorer = ConfluenceScorer("pulse_config.yaml")
+    result = scorer.score(sample_market_data)
+    
+    assert 'score' in result
+    assert 0 <= result['score'] <= 100
+    assert 'components' in result
+    assert 'reasoning' in result
+
+@pytest.mark.integration
+def test_risk_enforcer():
+    """Test risk enforcement"""
+    enforcer = RiskEnforcer()
+    
+    # Test with safe conditions
+    safe_signal = {
+        'confluence_score': 75,
+        'session_stats': {
+            'trades_today': 2,
+            'daily_pnl': -0.01,
+            'confidence_level': 0.5
+        },
+        'market_data': {}
+    }
+    
+    decision = enforcer.evaluate_signal(safe_signal)
+    assert 'approved' in decision
+    assert 'reason' in decision
+    assert 'risk_score' in decision
+
+@pytest.mark.integration
+def test_daily_loss_limit():
+    """Test daily loss limit protection"""
+    enforcer = RiskEnforcer()
+    
+    # Test with excessive loss
+    risky_signal = {
+        'confluence_score': 80,
+        'session_stats': {
+            'trades_today': 2,
+            'daily_pnl': -0.035,  # Exceeds 3% limit
+            'confidence_level': 0.5
+        },
+        'market_data': {}
+    }
+    
+    decision = enforcer.evaluate_signal(risky_signal)
+    assert decision['approved'] == False
+    assert 'DAILY_LIMIT_REACHED' in decision['flags']
+
+@pytest.mark.integration
+def test_overconfidence_protection():
+    """Test overconfidence detection"""
+    enforcer = RiskEnforcer()
+    enforcer.state['consecutive_wins'] = 4
+    enforcer.state['confidence_level'] = 0.9
+    
+    signal = {
+        'confluence_score': 85,
+        'session_stats': {'confidence_level': 0.9},
+        'market_data': {}
+    }
+    
+    decision = enforcer.evaluate_signal(signal)
+    assert 'OVERCONFIDENCE_ALERT' in decision.get('flags', [])
+
+# Run with: pytest tests/test_pulse_integration.py -v
+```
+
+## 7. Docker Integration (Priority: MEDIUM)
+
+### File: `docker-compose.yml` (UPDATE)
+```yaml
+# Add to existing services
+  pulse:
+    build: .
+    container_name: pulse_kernel
+    environment:
+      - REDIS_HOST=redis
+      - POSTGRES_HOST=postgres
+      - DJANGO_API_URL=http://django:8000
+    volumes:
+      - ./pulse_kernel.py:/app/pulse_kernel.py
+      - ./confluence_scorer.py:/app/confluence_scorer.py
+      - ./risk_enforcer.py:/app/risk_enforcer.py
+      - ./pulse_config.yaml:/app/pulse_config.yaml
+    depends_on:
+      - redis
+      - postgres
+      - django
+    networks:
+      - traefik-public
+    restart: unless-stopped
+```
+
+## 8. CI/CD Pipeline (Priority: LOW)
+
+### File: `.github/workflows/pulse_tests.yml` (NEW)
+```yaml
+name: Pulse Integration Tests
+
+on:
+  push:
+    paths:
+      - 'pulse_*.py'
+      - 'confluence_scorer.py'
+      - 'risk_enforcer.py'
+  pull_request:
+    paths:
+      - 'pulse_*.py'
+      - 'confluence_scorer.py'
+      - 'risk_enforcer.py'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install pytest pytest-cov
+    
+    - name: Run Pulse tests
+      run: |
+        pytest tests/test_pulse_integration.py -v --cov=./ --cov-report=xml
+    
+    - name: Upload coverage
+      uses: codecov/codecov-action@v2
+      with:
+        file: ./coverage.xml
+```
+
+## 📋 Implementation Priority Order
+
+**Week 1 (Immediate)**
+- Wire up existing analyzers in `confluence_scorer.py`
+- Create Django API views and URLs
+- Run integration tests with real components
+- Deploy to staging environment
+
+**Week 2 (Core Integration)**
+- Add Streamlit dashboard page
+- Integrate with Redis real-time streams
+- Add MTF resolver
+- Enhance error handling
+
+**Week 3 (Polish & Optimization)**
+- Add news buffer integration
+- Implement performance monitoring
+- Add comprehensive logging
+- Create user documentation
+
+**Week 4 (Production Ready)**
+- Complete CI/CD pipeline
+- Add alerting and notifications
+- Performance optimization
+- Security audit
+
+## 🎯 Success Criteria
+- All 6 risk modules actively protecting trades
+- Confluence scorer using real analyzer outputs
+- Dashboard showing real-time behavioral metrics
+- Daily loss frequency <10% in testing
+- Rule adherence >95% in testing
+- API response time <100ms for scoring
+- Zero critical security vulnerabilities
+
+## 📝 Notes
+- The existing analyzers (SMC, Wyckoff, Technical) need their interfaces documented
+- Consider implementing a feature flag system for gradual rollout
+- Add comprehensive logging for behavioral analysis
+- Consider adding a simulation mode for testing without real trades


### PR DESCRIPTION
## Summary
- Add comprehensive `PULSE_INTEGRATION_PLAN.md` outlining steps for wiring analyzers, API endpoints, dashboard, multi-timeframe resolver, news buffer, tests, Docker, and CI/CD.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ba2c08b370832888b737bbfeb9c77e