### PR TITLE
chore: add calibration workflow and streaming service

### DIFF
--- a/.github/workflows/weekly_calibration.yml
+++ b/.github/workflows/weekly_calibration.yml
@@ -1,60 +1,23 @@
-name: Weekly Wyckoff Weight Calibration
-
+name: Weekly Wyckoff Calibration
 on:
-  schedule:
-    # Runs every Sunday at 05:00 UTC
-    - cron: '0 5 * * 0'
-  workflow_dispatch: # Allows manual triggering for on-demand calibration
-
+  schedule: [{ cron: "0 3 * * 0" }]
+  workflow_dispatch: {}
 jobs:
-  calibrate-and-commit:
+  calibrate:
     runs-on: ubuntu-latest
     steps:
-      - name: 1. Checkout repository
-        uses: actions/checkout@v4
-
-      - name: 2. Set up Python environment
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: 3. Install dependencies
-        run: |
-          pip install -r requirements.txt
-          pip install pyyaml
-
-      - name: 4. Prepare Labeled Data
-        run: |
-          # IMPLEMENTATION NOTE: Replace this with your actual script to pull labeled data
-          # Example: python scripts/pull_labeled_data.py --output data/labeled_playback.pkl
-          echo "Placeholder for data preparation script."
-          mkdir -p data && touch data/labeled_playback.pkl
-
-      - name: 5. Run Calibration Script
-        id: calibration
-        run: |
-          # This script executes the grid search and outputs the best weights as a JSON string.
-          # It includes a performance improvement guardrail.
-          BEST_METRICS_JSON=$(python .github/scripts/run_calibration_with_guard.py \
-            --config-path pulse_config.yaml \
-            --data-path data/labeled_playback.pkl \
-            --min-improvement 0.05) # Require a 5% improvement to commit
-          echo "NEW_WEIGHTS=$BEST_METRICS_JSON" >> $GITHUB_ENV
-
-      - name: 6. Update Config File (if new weights are found)
-        if: env.NEW_WEIGHTS != '{}'
-        run: |
-          python .github/scripts/update_wyckoff_weights.py \
-            --config-path pulse_config.yaml \
-            --weights '${{ env.NEW_WEIGHTS }}'
-
-      - name: 7. Commit Updated Weights (if changed)
-        if: env.NEW_WEIGHTS != '{}'
-        uses: stefanzweifel/git-auto-commit-action@v5
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: python .github/scripts/run_calibration_with_guard.py
+      - name: Create PR if changed
+        uses: peter-evans/create-pull-request@v6
         with:
-          commit_message: "ci(wyckoff): auto-calibrate model weights"
-          branch: main
-          file_pattern: 'pulse_config.yaml'
-          commit_user_name: 'Zanalytics CI Bot'
-          commit_user_email: 'ci-bot@zanalytics.ai'
+          title: "chore: weekly wyckoff weights calibration"
+          commit-message: "chore: update wyckoff weights (auto)"
+          branch: "auto/calibrate-wyckoff"
+          base: "main"
+          labels: "calibration,auto"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -424,6 +424,16 @@ services:
       <<: *default-labels
     logging: *default-logging
 
+  tick-to-bar:
+    build: .
+    command: python services/tick_to_bar.py
+    environment:
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
+      - SYMBOL=EURUSD
+    depends_on:
+      - redis
+    restart: unless-stopped
+
   dashboard:
     build:
       context: ./dashboard

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration: mark integration tests
+

--- a/tests/test_pulse_integration.py
+++ b/tests/test_pulse_integration.py
@@ -1,5 +1,11 @@
 import pandas as pd
-from pulse_kernel import PulseKernel
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from pulse_kernel import PulseKernel, JournalEngine
 
 
 def _dummy_df(n=10):
@@ -14,11 +20,13 @@ def _dummy_df(n=10):
     return pd.DataFrame(data, index=idx)
 
 
-def test_full_pipeline_allows_when_rules_locked():
-    kernel = PulseKernel()
+@pytest.mark.integration
+def test_full_pipeline_allows_when_rules_locked(tmp_path):
+    journal = JournalEngine(path=tmp_path / "journal.json")
+    kernel = PulseKernel(journal=journal)
+    kernel.journal.log = lambda entry: None
     kernel.risk.lock_rules()
-    kernel.journal.log = lambda entry: None  # avoid filesystem writes
     df = _dummy_df()
     result = kernel.process(df)
-    assert 'score' in result
-    assert result['allowed'] is True
+    assert "score" in result
+    assert result["allowed"] is True

--- a/tests/test_wyckoff_adaptive.py
+++ b/tests/test_wyckoff_adaptive.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from components.wyckoff_adaptive import analyze_wyckoff_adaptive
+
+
+def test_analyze_wyckoff_adaptive_basic():
+    idx = pd.date_range("2025-01-01", periods=60, freq="T")
+    df = pd.DataFrame(
+        {
+            "open": 1.0,
+            "high": 1.0,
+            "low": 1.0,
+            "close": 1.0,
+            "volume": 100,
+        },
+        index=idx,
+    )
+    out = analyze_wyckoff_adaptive(df, win=30)
+    assert "phases" in out and len(out["phases"]["labels"]) == len(df)
+


### PR DESCRIPTION
## Summary
- add Redis tick-to-bar service for streaming data
- automate Wyckoff weight calibration via weekly GitHub workflow
- strengthen test suite with integration and adaptive Wyckoff coverage

## Testing
- `pytest -q tests/test_pulse_integration.py`
- `pytest -q tests/test_wyckoff_adaptive.py tests/test_wyckoff_extras.py`


------
https://chatgpt.com/codex/tasks/task_b_68ba2cd6e1f08328ac93ba5e83053f37