### PR TITLE
Expose MT5 API port and harden Pulse dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
     volumes:
       - ./config:/config
     ports:
+      - "8000:8000"
       - "5001:5001"
     networks:
       - traefik-public


### PR DESCRIPTION
## Summary
- Expose MT5 service on port 8000 for host access
- Add health checks, mock tick fallback, and VSA flag table to Pulse Wyckoff Live dashboard

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_68bc08425c6c832899d64d4c1ef56cf1