### PR TITLE
feat: add Dockerfile for tick-to-bar service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "services/tick_to_bar.py"]


### PR DESCRIPTION
## Summary
- add root Dockerfile installing requirements and running `services/tick_to_bar.py`

## Testing
- `docker compose build tick-to-bar` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ba3bc7bc748328b0247df8c8ae59bc