### PR TITLE
feat: add telegram alert integration

### DIFF
--- a/alerts/telegram_alerts.py
+++ b/alerts/telegram_alerts.py
@@ -1,67 +1,113 @@
+"""Telegram alert utilities.
+
+This module provides a simple, non-blocking notifier for Pulse that sends
+concise messages to Telegram.  Alerts are rate-limited per key to avoid
+spamming and never raise exceptions in the trading path.
+"""
+
+from __future__ import annotations
+
+import json
 import os
-import requests
-from typing import Dict
+import threading
+import time
+import urllib.request
+from typing import Any, Dict
 
-BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
-CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")
+BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
+CHAT_ID = os.getenv("TELEGRAM_CHAT_ID", "")
+ENABLED = os.getenv("ALERTS_ENABLED", "true").lower() == "true"
+MIN_GAP = float(os.getenv("ALERTS_MIN_INTERVAL_SECONDS", "60"))
+
+_last_sent: Dict[str, float] = {}
+_lock = threading.Lock()
 
 
-def send_telegram(message: str) -> bool:
-    """Send a message via Telegram bot. Returns True if successful."""
-    if not BOT_TOKEN or not CHAT_ID:
-        return False
+def _send(text: str) -> None:
+    """Send a message to Telegram if configured."""
+    if not (ENABLED and BOT_TOKEN and CHAT_ID):
+        return
+    url = f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage"
+    data = json.dumps({"chat_id": CHAT_ID, "text": text, "parse_mode": "HTML"}).encode()
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
     try:
-        url = f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage"
-        payload = {"chat_id": CHAT_ID, "text": message}
-        resp = requests.post(url, json=payload, timeout=10)
-        return resp.ok
+        urllib.request.urlopen(req, timeout=5)
     except Exception:
-        return False
-
-
-def alert_event(event: Dict) -> None:
-    """Send Telegram alerts based on risk/score events."""
-    decision = event.get("decision", {})
-    score_info = event.get("score", {})
-    features = event.get("features", {})
-    symbol = event.get("symbol", "")
-
-    score_val = score_info.get("score")
-    status = decision.get("status")
-    reasons = decision.get("reason", [])
-    toxicity = features.get("toxicity")
-
-    # Trade allowed
-    if status == "allowed":
-        if score_val is not None and score_val >= 90 and (toxicity is None or toxicity <= 0.3):
-            send_telegram(f"\U0001F9E0 {symbol} Top Signal – Score: {score_val:.0f}")
-        else:
-            send_telegram(f"\u2705 Signal allowed – {symbol} – Score: {score_val:.0f}")
-
-    # Trade blocked or warned
-    elif status in {"blocked", "warned"}:
-        reason_text = "; ".join(reasons)
-        if toxicity is not None and toxicity > 0.3:
-            send_telegram(f"\u26A0\uFE0F Blocked: Toxicity {toxicity:.2f} > limit")
-        elif reason_text:
-            prefix = "\u26A0\uFE0F" if status == "blocked" else "\u26A0\uFE0F"
-            send_telegram(f"{prefix} {reason_text}")
-
-    # Daily limit reached
-    if any("daily loss limit" in r.lower() for r in reasons):
-        send_telegram("\u26D4 Daily cap hit. All signals blocked.")
-
-    # Cooldown alerts
-    if any("cooling off period" in r.lower() for r in reasons):
-        send_telegram("\uD83D\uDD04 Cooldown started")
-
-    # Drawdown alert if available
-    raw = decision.get("raw", {})
-    account = raw.get("account_state", {})
-    try:
-        daily_pnl = abs(account.get("daily_pnl", 0))
-        starting = account.get("starting_equity") or 0
-        if starting and daily_pnl / starting > 0.025:
-            send_telegram(f"\U0001F4C9 Intraday DD: {daily_pnl / starting:.1%} – cooling triggered")
-    except Exception:
+        # Alerts must never break the trading loop
         pass
+
+
+def _should_throttle(key: str) -> bool:
+    """Return True if a message for ``key`` was recently sent."""
+    now = time.time()
+    with _lock:
+        last = _last_sent.get(key, 0.0)
+        if now - last < MIN_GAP:
+            return True
+        _last_sent[key] = now
+    return False
+
+
+def notify(event: Dict[str, Any]) -> None:
+    """Send a Telegram alert for ``event`` if thresholds are met."""
+    if not ENABLED:
+        return
+
+    sym = event.get("symbol", "—")
+    sc = event.get("score")
+    grd = event.get("grade")
+    rs = event.get("risk_status") or event.get("decision")
+    reasons = event.get("reasons") or []
+    metrics = event.get("metrics") or {}
+    account = event.get("account") or {}
+
+    tox = metrics.get("toxicity")
+    liq = metrics.get("liq_score")
+    ddp = account.get("dd_intraday")
+    tcnt = account.get("trades_today")
+    warn = event.get("warnings") or []
+    viol = event.get("violations") or []
+
+    key = None
+    text = None
+
+    hi = float(os.getenv("ALERTS_SCORE_HI", "90"))
+
+    # High-quality opportunity
+    if (
+        rs == "allowed"
+        and sc is not None
+        and sc >= hi
+        and tox is not None
+        and tox <= float(os.getenv("ALERTS_TOXICITY_LIMIT", "0.30"))
+    ):
+        key = f"hi:{sym}"
+        text = (
+            f"🧠 <b>Top signal</b> {sym} — Score {sc} ({grd})\n"
+            f"• Toxicity {tox:.2f} | Liquidity {liq if liq is not None else '—'}\n"
+            f"• Why: " + ", ".join(reasons[:3])
+        )
+
+    # Blocked by risk rules
+    if rs in ("blocked", "deny") or (viol and len(viol) > 0):
+        key = f"blk:{sym}:{','.join(sorted(set(viol)))}"
+        text = f"⛔ <b>Blocked</b> {sym}\n• Reasons: {', '.join(viol) or ', '.join(warn) or 'policy'}"
+
+    # Intraday drawdown / cooldown
+    dd_warn = float(os.getenv("ALERTS_DD_INTRADAY_WARN", "0.025"))
+    if ddp is not None and ddp >= dd_warn:
+        key = f"dd:{int(ddp * 1000)}"
+        text = f"📉 <b>Drawdown</b> {ddp * 100:.2f}% — cooldown active"
+
+    # Trade-count / frequency guard
+    if tcnt is not None:
+        key = key or f"tc:{tcnt}"
+        if tcnt in (3, 4, 5):
+            text = text or f"🧯 <b>Trade count</b> {tcnt} — frequency guard engaged"
+
+    if key and text and not _should_throttle(key):
+        _send(text)
+
+
+__all__ = ["notify"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,6 +156,13 @@ services:
       - PYTHONPATH=/app:/app/components:/app/utils:/app/backend
       - DJANGO_SETTINGS_MODULE=app.settings
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+      - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
+      - ALERTS_ENABLED=true
+      - ALERTS_MIN_INTERVAL_SECONDS=60
+      - ALERTS_SCORE_HI=90
+      - ALERTS_TOXICITY_LIMIT=0.30
+      - ALERTS_DD_INTRADAY_WARN=0.025
     depends_on:
       postgres:
         condition: service_started


### PR DESCRIPTION
## Summary
- add rate-limited Telegram notifier
- invoke alerts from Pulse kernel after journaling
- wire Telegram env vars into Django service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bc1ce9462483289254ce80888550ee