### PR TITLE
Add Pulse kernel orchestration stubs and risk config

### DIFF
--- a/confluence_scorer.py
+++ b/confluence_scorer.py
@@ -1,55 +1,243 @@
-"""Combine multiple analysis modules into a single confluence score."""
+"""
+ConfluenceScorer - Multi-Strategy Signal Fusion
+Wraps existing analyzers to produce unified scoring
+"""
 
-from __future__ import annotations
-from typing import Dict, Any
+import numpy as np
+from typing import Dict, List, Tuple
+import logging
 
+# Import existing analyzers (these already exist in the codebase)
+from components.smc_analyser import SMCAnalyzer
+from components.wyckoff_analyzer import WyckoffAnalyzer  
+from components.technical_analysis import TechnicalAnalysis
+
+logger = logging.getLogger(__name__)
 
 class ConfluenceScorer:
-    """Simple weighted ensemble of different analyzers.
-
-    Parameters
-    ----------
-    smc, wyckoff, technical, enhanced:
-        Analyzer instances exposing a ``score`` method that returns a mapping
-        with at least a ``score`` key.
-    weights:
-        Mapping of weightings for each component.  Missing analyzers are
-        treated as neutral (score of 0).
     """
-
-    def __init__(self, smc: Any, wyckoff: Any, technical: Any, enhanced: Any, weights: Dict[str, float]):
-        self.smc = smc
-        self.wyckoff = wyckoff
-        self.technical = technical
-        self.enhanced = enhanced
-        self.weights = weights
-
-    def score(self, data: Any) -> Dict[str, Any]:
-        """Return a confluence score aggregated from all analyzers."""
-
-        def _safe_score(analyzer: Any) -> Dict[str, Any]:
-            if analyzer is None:
-                return {"score": 0.0, "reasons": []}
-            try:
-                return analyzer.score(data)
-            except Exception:
-                # Fall back to neutral score if analyzer errors
-                return {"score": 0.0, "reasons": []}
-
-        smc = _safe_score(self.smc)
-        wy = _safe_score(self.wyckoff)
-        tech = _safe_score(self.technical)
-
-        score_val = (
-            smc.get("score", 0.0) * self.weights.get("smc", 0.0)
-            + wy.get("score", 0.0) * self.weights.get("wyckoff", 0.0)
-            + tech.get("score", 0.0) * self.weights.get("technical", 0.0)
-        )
-        grade = "Low" if score_val < 40 else "Medium" if score_val < 70 else "High"
-
+    Combines signals from multiple analysis methods into a single score.
+    This is a lightweight wrapper around existing heavy analyzers.
+    """
+    
+    def __init__(self, config: Dict = None):
+        # Initialize existing analyzers
+        self.smc = SMCAnalyzer()           # 35,895 LOC
+        self.wyckoff = WyckoffAnalyzer()   # 15,011 LOC
+        self.technical = TechnicalAnalysis() # 8,161 LOC
+        
+        # Default weights (configurable)
+        self.weights = config.get('weights', {
+            'smc': 0.4,
+            'wyckoff': 0.3,
+            'technical': 0.3
+        }) if config else {
+            'smc': 0.4,
+            'wyckoff': 0.3,
+            'technical': 0.3
+        }
+        
+        # Score thresholds
+        self.thresholds = {
+            'high': 80,
+            'medium': 60,
+            'low': 40
+        }
+        
+    def score(self, data: Dict) -> Dict:
+        """
+        Calculate confluence score from market data.
+        
+        Args:
+            data: Normalized market data frame
+            
+        Returns:
+            Dict with score, grade, components, and reasons
+        """
+        try:
+            # Get individual scores
+            smc_result = self._score_smc(data)
+            wyckoff_result = self._score_wyckoff(data)
+            technical_result = self._score_technical(data)
+            
+            # Calculate weighted score
+            final_score = (
+                smc_result['score'] * self.weights['smc'] +
+                wyckoff_result['score'] * self.weights['wyckoff'] +
+                technical_result['score'] * self.weights['technical']
+            )
+            
+            # Determine grade
+            grade = self._calculate_grade(final_score)
+            
+            # Compile reasons
+            reasons = self._compile_reasons(
+                smc_result, 
+                wyckoff_result, 
+                technical_result,
+                final_score
+            )
+            
+            return {
+                'score': round(final_score, 1),
+                'grade': grade,
+                'components': {
+                    'smc': smc_result['score'],
+                    'wyckoff': wyckoff_result['score'],
+                    'technical': technical_result['score']
+                },
+                'reasons': reasons,
+                'details': {
+                    'smc': smc_result['details'],
+                    'wyckoff': wyckoff_result['details'],
+                    'technical': technical_result['details']
+                }
+            }
+            
+        except Exception as e:
+            logger.error(f"Error calculating confluence score: {e}")
+            return {
+                'score': 0,
+                'grade': 'error',
+                'components': {},
+                'reasons': [f'Error: {str(e)}']
+            }
+    
+    def _score_smc(self, data: Dict) -> Dict:
+        """Calculate SMC-based score"""
+        # Call existing SMC analyzer
+        smc_analysis = self.smc.analyze(data.get('df', {}))
+        
+        score = 0
+        details = []
+        
+        # Score based on SMC concepts
+        if smc_analysis.get('order_blocks'):
+            score += 30
+            details.append('Order block detected')
+            
+        if smc_analysis.get('fair_value_gaps'):
+            score += 25
+            details.append('Fair value gap present')
+            
+        if smc_analysis.get('liquidity_sweeps'):
+            score += 25
+            details.append('Liquidity sweep confirmed')
+            
+        if smc_analysis.get('displacement'):
+            score += 20
+            details.append('Strong displacement')
+            
+        return {
+            'score': min(100, score),
+            'details': details
+        }
+    
+    def _score_wyckoff(self, data: Dict) -> Dict:
+        """Calculate Wyckoff-based score"""
+        # Call existing Wyckoff analyzer
+        wyckoff_analysis = self.wyckoff.analyze(data.get('df', {}))
+        
+        score = 0
+        details = []
+        
+        # Score based on Wyckoff phases
+        phase = wyckoff_analysis.get('current_phase', '')
+        
+        if phase == 'Accumulation':
+            score += 40
+            details.append('Accumulation phase')
+            
+        if 'spring' in str(wyckoff_analysis.get('spring_upthrust', {})):
+            score += 35
+            details.append('Wyckoff spring detected')
+            
+        if wyckoff_analysis.get('sos_sow'):
+            score += 25
+            details.append('Sign of strength')
+            
+        return {
+            'score': min(100, score),
+            'details': details
+        }
+    
+    def _score_technical(self, data: Dict) -> Dict:
+        """Calculate technical indicator score"""
+        # Call existing technical analysis
+        ta_analysis = self.technical.calculate_all(data.get('df', {}))
+        
+        score = 0
+        details = []
+        
+        # RSI conditions
+        rsi = ta_analysis.get('rsi', {})
+        if isinstance(rsi, dict):
+            rsi_value = rsi.get('value', 50)
+        else:
+            rsi_value = 50
+            
+        if rsi_value < 30:
+            score += 25
+            details.append('RSI oversold')
+        elif rsi_value > 70:
+            score += 25
+            details.append('RSI overbought')
+            
+        # MACD conditions
+        macd_diff = ta_analysis.get('macd_diff', 0)
+        if macd_diff > 0:
+            score += 25
+            details.append('MACD bullish')
+            
+        # Support/Resistance
+        if ta_analysis.get('support_resistance'):
+            score += 25
+            details.append('Near key level')
+            
+        # Volume confirmation
+        if self._check_volume_confirmation(ta_analysis):
+            score += 25
+            details.append('Volume confirms')
+            
+        return {
+            'score': min(100, score),
+            'details': details
+        }
+    
+    def _check_volume_confirmation(self, ta_analysis: Dict) -> bool:
+        """Check if volume confirms the move"""
+        # Simplified volume check
+        return ta_analysis.get('volume_sma', 0) > 0
+    
+    def _calculate_grade(self, score: float) -> str:
+        """Convert numeric score to grade"""
+        if score >= self.thresholds['high']:
+            return 'high'
+        elif score >= self.thresholds['medium']:
+            return 'medium'
+        elif score >= self.thresholds['low']:
+            return 'low'
+        else:
+            return 'minimal'
+    
+    def _compile_reasons(self, smc: Dict, wyckoff: Dict, technical: Dict, score: float) -> List[str]:
+        """Compile human-readable reasons for the score"""
         reasons = []
-        for part in (smc, wy, tech):
-            reasons.extend(part.get("reasons", []))
-
-        return {"score": score_val, "grade": grade, "reasons": reasons}
-
+        
+        # Add top reasons from each component
+        if smc['score'] > 70:
+            reasons.extend(smc['details'][:2])
+        if wyckoff['score'] > 70:
+            reasons.extend(wyckoff['details'][:2])
+        if technical['score'] > 70:
+            reasons.extend(technical['details'][:2])
+            
+        # Add overall assessment
+        if score >= 80:
+            reasons.insert(0, '🎯 HIGH CONFLUENCE SETUP')
+        elif score >= 60:
+            reasons.insert(0, '⚡ MEDIUM CONFLUENCE')
+        else:
+            reasons.insert(0, '⚠️ LOW CONFLUENCE')
+            
+        return reasons[:5]  # Limit to top 5 reasons

--- a/pulse_config.yaml
+++ b/pulse_config.yaml
@@ -1,149 +1,76 @@
-# Zanalytics Pulse - Scientific Risk Configuration
-pulse:
-  version: "v11.5.1"
+# Zanalytics Pulse Configuration
+# Version: 11.5.1
+
+system:
+  name: "Zanalytics Pulse"
+  version: "11.5.1"
   environment: "production"
 
-# Scientific Risk Management Parameters
-risk_management:
-  # Daily loss limits with psychological buffers
-  daily_loss_limit: 0.03  # 3% buffer under 5% prop limit
-  warning_threshold: 0.02  # 2% warning level
+redis:
+  host: "localhost"
+  port: 6379
+  db: 0
+  password: null
+
+confluence_weights:
+  smc: 0.4          # Smart Money Concepts
+  wyckoff: 0.3      # Wyckoff Analysis
+  technical: 0.3    # Technical Indicators
+
+risk_limits:
+  daily_loss_limit: 500           # USD
+  daily_loss_percent: 0.03        # 3% of account
+  max_trades_per_day: 5
+  max_position_size: 0.02         # 2% risk per trade
+  cooling_period_minutes: 15
+  revenge_trade_window: 30        # minutes
+  max_consecutive_losses: 3
+
+behavioral:
+  revenge_trade_threshold: 3
+  overconfidence_threshold: 4
+  fatigue_hour: 22
+  optimal_hours: [9, 10, 11, 14, 15, 16]
   
-  # Risk phases with scientific adjustments
-  risk_phases:
-    low_equity:
-      per_trade_risk: 0.003  # 0.3% conservative risk
-      max_trades_per_day: 2
-      description: "Conservative phase - building confidence"
-      
-    stable:
-      per_trade_risk: 0.005  # 0.5% normal risk
-      max_trades_per_day: 3
-      description: "Stable phase - moderate risk"
-      
-    new_high:
-      per_trade_risk: 0.007  # 0.7% growth risk
-      max_trades_per_day: 4
-      description: "Growth phase - optimal risk"
-      
-    recovery:
-      per_trade_risk: 0.004  # 0.4% recovery risk
-      max_trades_per_day: 2
-      description: "Recovery phase - risk reduction"
+position_breakdown:
+  enabled: true
+  default_splits: 5               # Split position into 5 parts
+  min_confluence_per_entry: 60    # Minimum score for each entry
+  scale_in_increment: 5           # Confluence points between entries
 
-# Behavioral Psychology Safeguards
-behavioral_safeguards:
-  # Overconfidence protection
-  overconfidence_protection:
-    rapid_trading_threshold: 5  # minutes between trades
-    consecutive_wins_limit: 3
-    size_reduction_factor: 0.8
-    high_confidence_threshold: 85  # Confluence score threshold
+telegram:
+  enabled: true
+  bot_token: "${TELEGRAM_BOT_TOKEN}"
+  chat_id: "${TELEGRAM_CHAT_ID}"
+  alert_types:
+    - high_confluence
+    - risk_warning
+    - behavioral_alert
+    - daily_summary
     
-  # Revenge trading prevention
-  revenge_trading_prevention:
-    consecutive_loss_limit: 2
-    cooldown_minutes: 15
-    detection_window_minutes: 30
-    
-  # Disposition effect mitigation
-  disposition_effect_mitigation:
-    min_risk_reward: 1.5
-    auto_exit_rules: true
-    loss_limit_enforcement: "strict"
-    
-  # Trading fatigue management
-  fatigue_management:
-    max_trades_per_day: 5
-    warning_threshold: 4
-    fatigue_multiplier: 0.7
+ui:
+  refresh_rate: 2                 # seconds
+  theme: "dark"
+  show_behavioral_state: true
+  show_position_breakdown: true
+  show_journal_prompts: true
 
-# Scientific Position Sizing Parameters
-position_sizing:
-  # Base multipliers for different factors
-  confidence_multiplier:
-    low: 0.5      # < 40 confluence score
-    medium: 0.75  # 40-70 confluence score
-    high: 1.0     # > 70 confluence score
-    
-  phase_multiplier:
-    low_equity: 0.7
-    stable: 1.0
-    new_high: 1.2
-    recovery: 0.6
-    
-  behavioral_multiplier:
-    normal: 1.0
-    consecutive_losses: 0.5
-    high_frequency: 0.8
-    fatigue: 0.7
+journal:
+  auto_prompt: true
+  prompt_on_loss: true
+  prompt_on_win_streak: true
+  weekly_review: true
+  storage_path: "/data/journal"
 
-# Confluence Scoring with Scientific Weighting
-confluence_scoring:
-  weights:
-    smc: 0.35
-    wyckoff: 0.35
-    technical: 0.20
-    midas: 0.10
-    
-  thresholds:
-    low: 40
-    medium: 60
-    high: 80
-    
-  minimum_factors: 2
-
-# Performance Targets with Scientific Basis
-performance_targets:
-  daily_loss_frequency: 0.10    # <10% based on academic research
-  rule_adherence: 0.95          # >95% based on behavioral studies
-  ui_response_time: 2.0         # <2s for cognitive load optimization
-  decision_latency: 0.1         # <100ms for real-time trading
-  risk_efficiency: 0.75         # >75% based on portfolio theory
-
-# Integration Settings
-integration:
-  django_api:
-    base_url: "${DJANGO_API_URL:-http://django:8000}"
-    timeout: 2.0
-    
-  redis:
-    host: "${REDIS_HOST:-redis}"
-    port: "${REDIS_PORT:-6379}"
-    cache_ttl: 300
-    
-  mt5_api:
-    login: "${MT5_LOGIN:-}"
-    password: "${MT5_PASSWORD:-}"
-    server: "${MT5_SERVER:-}"
-
-# Logging and Monitoring
-logging:
-  level: "INFO"
-  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-  
 monitoring:
-  health_check_interval: 30
-  alert_thresholds:
-    api_latency: 1000  # ms
-    memory_usage: 80   # percent
-    
-# Dashboard Configuration
-dashboard:
-  refresh_interval: 5  # seconds
-  max_recent_decisions: 20
-  auto_refresh: false
-  
-  tiles:
-    - confluence_score
-    - market_bias
-    - risk_remaining
-    - suggested_rr
-    - top_opportunities
-    - behavioral_insights
-  
-  psychology_features:
-    - risk_allocation_visualization
-    - behavioral_insights_panel
-    - trading_principles_reminder
-    - fatigue_monitoring
+  metrics_port: 9090
+  health_check_interval: 30      # seconds
+  alert_on_error: true
+
+api_endpoints:
+  pulse_frame: "/api/pulse/frame"
+  pulse_health: "/api/pulse/health"
+  pulse_score: "/api/pulse/score"
+  pulse_risk: "/api/pulse/risk"
+  pulse_journal: "/api/pulse/journal"
+  signals_top: "/api/signals/top"

--- a/risk_enforcer.py
+++ b/risk_enforcer.py
@@ -1,546 +1,310 @@
 """
-Enhanced Risk Enforcer - Scientific Position Sizing with Behavioral Psychology
+RiskEnforcer - Behavioral Protection System
+Enforces trading discipline and risk management rules
 """
-import os
-import json
-import redis
-import logging
+
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
-from dataclasses import dataclass
-from enum import Enum
-import yaml
-import numpy as np
+import json
+import logging
 
-# Safe MT5 import
-try:
-    import MetaTrader5 as mt5
-    MT5_AVAILABLE = True
-except ImportError:
-    MT5_AVAILABLE = False
-    mt5 = None
+logger = logging.getLogger(__name__)
 
-class RiskPhase(Enum):
-    LOW_EQUITY = "low_equity"
-    STABLE = "stable"
-    NEW_HIGH = "new_high"
-    RECOVERY = "recovery"
-
-class RiskDecision(Enum):
-    ALLOW = "allow"
-    WARN = "warn"
-    BLOCK = "block"
-
-@dataclass
-class RiskLimits:
-    daily_loss_limit: float = 0.03  # 3% buffer under 5% prop limit
-    per_trade_risk: float = 0.005   # 0.5% starting risk
-    max_trades_per_day: int = 5
-    consecutive_loss_limit: int = 2
-    cooldown_minutes: int = 15
-
-@dataclass
-class AccountState:
-    current_equity: float
-    starting_equity: float
-    peak_equity: float
-    daily_pnl: float
-    trades_today: int
-    consecutive_losses: int
-    last_trade_time: Optional[datetime] = None
-
-class EnhancedRiskEnforcer:
-    """Scientific Risk Enforcer with Behavioral Psychology Integration"""
+class RiskEnforcer:
+    """
+    Enforces risk management rules and behavioral safeguards.
+    Acts as the "seatbelt" for trading decisions.
+    """
     
-    def __init__(self, config_path: str = "pulse_config.yaml"):
-        self.config = self._load_config(config_path)
-        self.logger = logging.getLogger(__name__)
+    def __init__(self, config: Dict = None):
+        # Risk limits (configurable)
+        self.limits = config.get('limits', {
+            'daily_loss_limit': 500,        # USD
+            'daily_loss_percent': 0.03,     # 3% (buffer before 5% prop limit)
+            'max_trades_per_day': 5,
+            'max_position_size': 0.02,      # 2% max risk per trade
+            'cooling_period_minutes': 15,
+            'revenge_trade_window': 30,     # minutes
+            'max_consecutive_losses': 3
+        }) if config else self._default_limits()
         
-        # Redis connection with error handling
-        try:
-            self.redis_client = redis.Redis(
-                host=os.getenv('REDIS_HOST', 'redis'),
-                port=int(os.getenv('REDIS_PORT', 6379)),
-                decode_responses=True,
-                socket_timeout=2.0,
-                socket_connect_timeout=2.0
-            )
-            self.redis_client.ping()
-            self.redis_available = True
-        except Exception as e:
-            self.logger.warning(f"Redis unavailable: {e}")
-            self.redis_available = False
-            self.redis_client = None
+        # Current state
+        self.daily_stats = {
+            'date': datetime.now().date(),
+            'trades_count': 0,
+            'total_pnl': 0,
+            'losses_count': 0,
+            'consecutive_losses': 0,
+            'last_loss_time': None,
+            'cooling_until': None,
+            'violations': []
+        }
         
-        # MT5 lazy initialization
-        self.mt5_connected = False
-        self.mt5_available = MT5_AVAILABLE
+        # Behavioral tracking
+        self.behavioral_flags = {
+            'revenge_trading': False,
+            'overconfidence': False,
+            'fatigue': False,
+            'tilt': False
+        }
         
-        # Risk limits by phase with scientific adjustments
-        self.risk_limits = {
-            RiskPhase.LOW_EQUITY: RiskLimits(per_trade_risk=0.003, max_trades_per_day=2),  # Conservative
-            RiskPhase.STABLE: RiskLimits(per_trade_risk=0.005, max_trades_per_day=3),       # Moderate
-            RiskPhase.NEW_HIGH: RiskLimits(per_trade_risk=0.007, max_trades_per_day=4),     # Growth
-            RiskPhase.RECOVERY: RiskLimits(per_trade_risk=0.004, max_trades_per_day=2)      # Recovery
+    def _default_limits(self) -> Dict:
+        """Default risk limits"""
+        return {
+            'daily_loss_limit': 500,
+            'daily_loss_percent': 0.03,
+            'max_trades_per_day': 5,
+            'max_position_size': 0.02,
+            'cooling_period_minutes': 15,
+            'revenge_trade_window': 30,
+            'max_consecutive_losses': 3
         }
     
-    def _load_config(self, config_path: str) -> Dict:
-        """Load configuration with error handling"""
-        try:
-            with open(config_path, 'r') as f:
-                return yaml.safe_load(f)
-        except FileNotFoundError:
-            self.logger.warning(f"Config file {config_path} not found, using defaults")
-            return {}
-        except Exception as e:
-            self.logger.error(f"Error loading config: {e}")
-            return {}
-    
-    def _init_mt5(self) -> bool:
-        """Initialize MT5 connection safely"""
-        if not self.mt5_available:
-            self.logger.info("MT5 not available, using mock mode")
-            return False
-        
-        try:
-            if not mt5.initialize():
-                self.logger.warning("MT5 initialize failed")
-                return False
-            
-            # Only attempt login if credentials provided
-            login = os.getenv('MT5_LOGIN')
-            password = os.getenv('MT5_PASSWORD')
-            server = os.getenv('MT5_SERVER')
-            
-            if login and password and server:
-                success = mt5.login(login=int(login), password=password, server=server)
-                if success:
-                    self.logger.info("MT5 login successful")
-                    return True
-                else:
-                    self.logger.warning("MT5 login failed")
-                    return False
-            else:
-                self.logger.info("MT5 credentials not provided, terminal initialized without login")
-                return True
-                
-        except Exception as e:
-            self.logger.error(f"MT5 initialization error: {e}")
-            return False
-    
-    def _ensure_mt5(self):
-        """Ensure MT5 connection with lazy initialization"""
-        if not self.mt5_connected and self.mt5_available:
-            self.mt5_connected = self._init_mt5()
-    
-    def get_current_account_state(self) -> AccountState:
-        """Get current account state with fallback to mock data"""
-        self._ensure_mt5()
-        
-        if not self.mt5_connected:
-            # Return safe mock data for testing/development
-            return AccountState(
-                current_equity=10000.0,
-                starting_equity=10000.0,
-                peak_equity=10000.0,
-                daily_pnl=0.0,
-                trades_today=0,
-                consecutive_losses=0,
-                last_trade_time=None
-            )
-        
-        try:
-            account_info = mt5.account_info()
-            if not account_info:
-                raise RuntimeError("MT5 account_info unavailable")
-            
-            daily_stats = self._get_daily_stats()
-            
-            return AccountState(
-                current_equity=account_info.equity,
-                starting_equity=account_info.balance,
-                peak_equity=max(account_info.equity, account_info.balance),
-                daily_pnl=account_info.profit,
-                trades_today=daily_stats.get('trades_today', 0),
-                consecutive_losses=daily_stats.get('consecutive_losses', 0),
-                last_trade_time=daily_stats.get('last_trade_time')
-            )
-        except Exception as e:
-            self.logger.error(f"Error getting account state: {e}")
-            # Return safe fallback
-            return AccountState(10000.0, 10000.0, 10000.0, 0.0, 0, 0, None)
-    
-    def _get_daily_stats(self) -> Dict:
-        """Get daily trading statistics with error handling"""
-        if not self.mt5_connected:
-            return {'trades_today': 0, 'consecutive_losses': 0, 'last_trade_time': None}
-        
-        try:
-            start_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-            end_date = datetime.now()
-            
-            deals = mt5.history_deals_get(start_date, end_date)
-            if not deals:
-                return {'trades_today': 0, 'consecutive_losses': 0, 'last_trade_time': None}
-            
-            # Calculate consecutive losses
-            consecutive_losses = 0
-            last_trade_time = None
-            
-            for deal in reversed(deals):
-                if deal.profit < 0:
-                    consecutive_losses += 1
-                    if last_trade_time is None:
-                        last_trade_time = datetime.fromtimestamp(deal.time)
-                else:
-                    break
-            
-            return {
-                'trades_today': len(deals),
-                'consecutive_losses': consecutive_losses,
-                'last_trade_time': last_trade_time
-            }
-        except Exception as e:
-            self.logger.error(f"Error getting daily stats: {e}")
-            return {'trades_today': 0, 'consecutive_losses': 0, 'last_trade_time': None}
-    
-    def determine_risk_phase(self, account_state: AccountState) -> RiskPhase:
-        """Determine current risk phase based on account performance"""
-        try:
-            equity_ratio = account_state.current_equity / account_state.starting_equity
-            peak_ratio = account_state.current_equity / account_state.peak_equity
-            
-            if equity_ratio < 1.02:  # Less than 2% gain
-                return RiskPhase.LOW_EQUITY
-            elif account_state.current_equity > account_state.peak_equity:
-                return RiskPhase.NEW_HIGH
-            elif peak_ratio >= 0.98:  # Within 2% of peak
-                return RiskPhase.STABLE
-            else:
-                return RiskPhase.RECOVERY
-        except (ZeroDivisionError, TypeError):
-            return RiskPhase.LOW_EQUITY
-    
-    def calculate_dynamic_position_size(self, 
-                                      account_state: AccountState,
-                                      signal_confidence: float,
-                                      stop_loss_pips: float,
-                                      pip_value: float,
-                                      max_daily_risk_pct: float = 2.0,
-                                      anticipated_trades: int = 3) -> Dict:
+    def allow(self, signal: Dict) -> Tuple[bool, List[str], Dict]:
         """
-        Scientific position sizing with behavioral psychology integration
+        Main enforcement method - checks if a trade should be allowed.
         
         Args:
-            account_state: Current account state
-            signal_confidence: Confluence score (0-100)
-            stop_loss_pips: Stop loss distance in pips
-            pip_value: Value per pip
-            max_daily_risk_pct: Maximum daily risk percentage
-            anticipated_trades: Number of trades planned for the day
+            signal: Trade signal with score, size, etc.
+            
+        Returns:
+            Tuple of (allowed, warnings, details)
         """
+        allowed = True
+        warnings = []
+        details = {}
         
-        # Base risk calculation
-        daily_risk_amount = account_state.current_equity * (max_daily_risk_pct / 100)
-        per_trade_risk = daily_risk_amount / anticipated_trades
-        
-        # Confidence-based adjustment (psychological factor)
-        confidence_multiplier = min(1.0, signal_confidence / 100)  # Cap at 100%
-        
-        # Risk phase adjustment (scientific factor)
-        risk_phase = self.determine_risk_phase(account_state)
-        phase_multiplier = {
-            RiskPhase.LOW_EQUITY: 0.7,   # Reduce risk in low equity phase
-            RiskPhase.STABLE: 1.0,       # Normal risk
-            RiskPhase.NEW_HIGH: 1.2,     # Increase risk in new high phase
-            RiskPhase.RECOVERY: 0.6      # Conservative in recovery
-        }.get(risk_phase, 1.0)
-        
-        # Behavioral adjustment (psychological factor)
-        behavioral_multiplier = 1.0
-        if account_state.consecutive_losses >= 2:
-            behavioral_multiplier = 0.5  # Reduce risk after consecutive losses
-        elif account_state.trades_today >= anticipated_trades * 0.8:
-            behavioral_multiplier = 0.8  # Reduce risk near trade limit
-        
-        # Calculate final position size
-        adjusted_risk = per_trade_risk * confidence_multiplier * phase_multiplier * behavioral_multiplier
-        
-        if stop_loss_pips > 0 and pip_value > 0:
-            position_size = round(adjusted_risk / (stop_loss_pips * pip_value), 2)
-        else:
-            position_size = 0
-        
-        return {
-            "position_size": position_size,
-            "risk_amount": adjusted_risk,
-            "confidence_multiplier": confidence_multiplier,
-            "phase_multiplier": phase_multiplier,
-            "behavioral_multiplier": behavioral_multiplier,
-            "effective_multiplier": confidence_multiplier * phase_multiplier * behavioral_multiplier,
-            "risk_phase": risk_phase.value
+        # Check daily loss limit
+        loss_check = self._check_daily_loss()
+        if not loss_check['allowed']:
+            allowed = False
+            warnings.append(loss_check['reason'])
+            
+        # Check trade count
+        count_check = self._check_trade_count()
+        if not count_check['allowed']:
+            allowed = False
+            warnings.append(count_check['reason'])
+        elif count_check.get('warning'):
+            warnings.append(count_check['warning'])
+            
+        # Check cooling period
+        cooling_check = self._check_cooling_period()
+        if not cooling_check['allowed']:
+            allowed = False
+            warnings.append(cooling_check['reason'])
+            
+        # Check position size
+        size_check = self._check_position_size(signal.get('size', 0))
+        if not size_check['allowed']:
+            allowed = False
+            warnings.append(size_check['reason'])
+            
+        # Check behavioral patterns
+        behavioral_check = self._check_behavioral_patterns()
+        if behavioral_check['warnings']:
+            warnings.extend(behavioral_check['warnings'])
+            
+        # Check for revenge trading
+        revenge_check = self._check_revenge_trading()
+        if revenge_check['detected']:
+            warnings.append('⚠️ Revenge trading pattern detected')
+            self.behavioral_flags['revenge_trading'] = True
+            
+        # Check for overconfidence
+        confidence_check = self._check_overconfidence()
+        if confidence_check['detected']:
+            warnings.append('⚠️ Overconfidence detected - consider smaller size')
+            self.behavioral_flags['overconfidence'] = True
+            
+        # Compile details
+        details = {
+            'trades_remaining': self.limits['max_trades_per_day'] - self.daily_stats['trades_count'],
+            'loss_buffer': self.limits['daily_loss_limit'] - abs(self.daily_stats['total_pnl']),
+            'behavioral_score': self._calculate_behavioral_score(),
+            'risk_level': self._calculate_risk_level(),
+            'flags': self.behavioral_flags
         }
+        
+        return allowed, warnings, details
     
-    def check_behavioral_patterns(self, account_state: AccountState, signal: Dict) -> Tuple[RiskDecision, str]:
-        """Check for behavioral trading patterns with psychological insights"""
-        flags = []
+    def _check_daily_loss(self) -> Dict:
+        """Check if daily loss limit is exceeded"""
+        if self.daily_stats['total_pnl'] <= -self.limits['daily_loss_limit']:
+            return {
+                'allowed': False,
+                'reason': '🔴 Daily loss limit reached. No more trades today.'
+            }
         
-        try:
-            # Overconfidence check (high confluence score after wins)
-            if (signal.get('confluence_score', 0) > 85 and 
-                account_state.consecutive_losses == 0 and 
-                account_state.trades_today >= 3):
-                flags.append("overconfidence_risk")
-            
-            # Revenge trading check
-            if (account_state.consecutive_losses >= 2 and 
-                account_state.last_trade_time and
-                datetime.now() - account_state.last_trade_time < timedelta(minutes=30)):
-                flags.append("revenge_trading_risk")
-            
-            # Disposition effect check
-            if (account_state.daily_pnl < 0 and 
-                signal.get('risk_reward', 0) < 1.5):
-                flags.append("disposition_effect_risk")
-            
-            # Fatigue check
-            if account_state.trades_today >= 5:
-                flags.append("trading_fatigue")
-            
-            if flags:
-                return RiskDecision.WARN, f"Behavioral flags: {', '.join(flags)}"
-            
-            return RiskDecision.ALLOW, "No behavioral red flags detected"
-            
-        except Exception as e:
-            self.logger.error(f"Error in behavioral check: {e}")
-            return RiskDecision.WARN, "Behavioral check error"
-
-    def check(self, ts: str, symbol: str, score: float, features: Dict | None = None) -> Dict:
-        """Compatibility wrapper for legacy interface"""
-        if features and features.get('news_active'):
-            return {'status': 'blocked', 'reason': ['News event active'], 'raw': {}}
-
-        signal = {'symbol': symbol, 'confluence_score': score}
-        if features:
-            signal.update(features)
-
-        result = self.evaluate_trade_request(signal)
-        status_map = {'allow': 'allowed', 'warn': 'warned', 'block': 'blocked'}
-        return {
-            'status': status_map.get(result['decision'], 'blocked'),
-            'reason': result.get('reasons', []),
-            'raw': result
-        }
-
-    def evaluate_trade_request(self, signal: Dict, account_state: Optional[AccountState] = None) -> Dict:
-        """Comprehensive trade evaluation with scientific position sizing"""
-        try:
-            if account_state is None:
-                account_state = self.get_current_account_state()
-            
-            risk_phase = self.determine_risk_phase(account_state)
-            limits = self.risk_limits[risk_phase]
-            
-            # Run all risk checks
-            checks = {
-                "daily_loss": self._check_daily_loss_limit(account_state, limits),
-                "trade_frequency": self._check_trade_frequency(account_state, limits),
-                "behavioral": self.check_behavioral_patterns(account_state, signal),
-                "cooldown": self._check_cooldown_period(account_state, limits)
+        # Warning if close to limit
+        if self.daily_stats['total_pnl'] <= -self.limits['daily_loss_limit'] * 0.8:
+            return {
+                'allowed': True,
+                'warning': '⚠️ Approaching daily loss limit (80% reached)'
             }
             
-            # Determine overall decision
-            decisions = [check[0] for check in checks.values()]
-            reasons = [check[1] for check in checks.values() if check[1]]
+        return {'allowed': True}
+    
+    def _check_trade_count(self) -> Dict:
+        """Check if max trades per day exceeded"""
+        if self.daily_stats['trades_count'] >= self.limits['max_trades_per_day']:
+            return {
+                'allowed': False,
+                'reason': '🔴 Maximum trades per day reached.'
+            }
             
-            if RiskDecision.BLOCK in decisions:
-                overall_decision = RiskDecision.BLOCK
-            elif RiskDecision.WARN in decisions:
-                overall_decision = RiskDecision.WARN
+        if self.daily_stats['trades_count'] == self.limits['max_trades_per_day'] - 1:
+            return {
+                'allowed': True,
+                'warning': '⚠️ This is your last trade for today'
+            }
+            
+        return {'allowed': True}
+    
+    def _check_cooling_period(self) -> Dict:
+        """Check if cooling period is active"""
+        if self.daily_stats['cooling_until']:
+            if datetime.now() < self.daily_stats['cooling_until']:
+                remaining = (self.daily_stats['cooling_until'] - datetime.now()).seconds // 60
+                return {
+                    'allowed': False,
+                    'reason': f'❄️ Cooling period active. {remaining} minutes remaining.'
+                }
             else:
-                overall_decision = RiskDecision.ALLOW
-            
-            # Calculate position size if allowed
-            position_sizing = {}
-            if overall_decision != RiskDecision.BLOCK:
-                # Get user-defined parameters from signal or defaults
-                max_daily_risk = signal.get('max_daily_risk_pct', 2.0)
-                anticipated_trades = signal.get('anticipated_trades', 3)
-                stop_loss_pips = signal.get('stop_loss_pips', 20)
-                pip_value = signal.get('pip_value', 1.0)
-                confluence_score = signal.get('confluence_score', 75)
+                # Cooling period expired
+                self.daily_stats['cooling_until'] = None
                 
-                position_sizing = self.calculate_dynamic_position_size(
-                    account_state,
-                    confluence_score,
-                    stop_loss_pips,
-                    pip_value,
-                    max_daily_risk,
-                    anticipated_trades
-                )
-            
-            result = {
-                "decision": overall_decision.value,
-                "allowed": overall_decision == RiskDecision.ALLOW,
-                "risk_phase": risk_phase.value,
-                "position_sizing": position_sizing,
-                "position_size": position_sizing.get("position_size", 0),
-                "reasons": reasons,
-                "behavioral_flags": [r for r in reasons if any(flag in r.lower() for flag in ['overconfidence', 'revenge', 'disposition', 'fatigue'])],
-                "risk_level": "critical" if overall_decision == RiskDecision.BLOCK else "medium" if overall_decision == RiskDecision.WARN else "low",
-                "remaining_budget": max(0, limits.daily_loss_limit - abs(account_state.daily_pnl / account_state.starting_equity)),
-                "trades_remaining": max(0, limits.max_trades_per_day - account_state.trades_today),
-                "timestamp": datetime.now().isoformat()
-            }
-            
-            # Log decision safely
-            self._log_decision(signal, account_state, result)
-            
-            return result
-            
-        except Exception as e:
-            self.logger.error(f"Error in trade evaluation: {e}")
+        return {'allowed': True}
+    
+    def _check_position_size(self, size: float) -> Dict:
+        """Check if position size is within limits"""
+        if size > self.limits['max_position_size']:
             return {
-                "decision": "block",
-                "allowed": False,
-                "risk_phase": "unknown",
-                "position_size": 0,
-                "reasons": [f"System error: {str(e)}"],
-                "behavioral_flags": [],
-                "risk_level": "critical",
-                "remaining_budget": 0,
-                "trades_remaining": 0,
-                "timestamp": datetime.now().isoformat()
+                'allowed': False,
+                'reason': f'🔴 Position size {size:.1%} exceeds maximum {self.limits["max_position_size"]:.1%}'
             }
+        return {'allowed': True}
     
-    def _check_daily_loss_limit(self, account_state: AccountState, limits: RiskLimits) -> Tuple[RiskDecision, str]:
-        """Check if daily loss limit would be breached"""
-        try:
-            daily_loss_pct = abs(account_state.daily_pnl) / account_state.starting_equity
-            
-            if daily_loss_pct >= limits.daily_loss_limit:
-                return RiskDecision.BLOCK, f"Daily loss limit reached: {daily_loss_pct:.2%}"
-            elif daily_loss_pct >= 0.02:  # 2% warning threshold
-                return RiskDecision.WARN, f"Approaching daily loss limit: {daily_loss_pct:.2%}"
-            
-            return RiskDecision.ALLOW, "Daily loss within limits"
-        except (ZeroDivisionError, TypeError):
-            return RiskDecision.WARN, "Unable to calculate daily loss"
-    
-    def _check_trade_frequency(self, account_state: AccountState, limits: RiskLimits) -> Tuple[RiskDecision, str]:
-        """Check trade frequency limits"""
-        if account_state.trades_today >= limits.max_trades_per_day:
-            return RiskDecision.BLOCK, f"Max trades per day reached: {account_state.trades_today}/{limits.max_trades_per_day}"
-        
-        return RiskDecision.ALLOW, "Trade frequency within limits"
-    
-    def _check_cooldown_period(self, account_state: AccountState, limits: RiskLimits) -> Tuple[RiskDecision, str]:
-        """Check cooling off period after losses"""
-        if (account_state.consecutive_losses >= limits.consecutive_loss_limit and 
-            account_state.last_trade_time and 
-            datetime.now() - account_state.last_trade_time < timedelta(minutes=limits.cooldown_minutes)):
-            return RiskDecision.BLOCK, f"Cooling off period active: {limits.cooldown_minutes} minutes after {account_state.consecutive_losses} losses"
-        
-        return RiskDecision.ALLOW, "No cooldown active"
-    
-    def _log_decision(self, signal: Dict, account_state: AccountState, result: Dict):
-        """Log risk decision with error handling"""
-        if not self.redis_available:
-            return
-        
-        try:
-            log_entry = {
-                "timestamp": datetime.now().isoformat(),
-                "symbol": signal.get("symbol"),
-                "confluence_score": signal.get("confluence_score"),
-                "decision": result["decision"],
-                "risk_phase": result["risk_phase"],
-                "account_equity": account_state.current_equity,
-                "daily_pnl": account_state.daily_pnl,
-                "trades_today": account_state.trades_today,
-                "position_size": result.get("position_size", 0),
-                "reasons": result["reasons"]
-            }
-            
-            # Store in Redis with expiration
-            key = f"risk_log:{datetime.now().strftime('%Y%m%d')}"
-            self.redis_client.lpush(key, json.dumps(log_entry))
-            self.redis_client.expire(key, 86400 * 7)  # Keep for 7 days
-            
-        except Exception as e:
-            self.logger.error(f"Error logging decision: {e}")
-    
-    def get_risk_status(self, account_state: Optional[AccountState] = None) -> Dict:
-        """Get current risk status for dashboard"""
-        try:
-            if account_state is None:
-                account_state = self.get_current_account_state()
-            
-            risk_phase = self.determine_risk_phase(account_state)
-            limits = self.risk_limits[risk_phase]
-            
-            daily_loss_pct = abs(account_state.daily_pnl) / account_state.starting_equity
-            risk_used_pct = (daily_loss_pct / limits.daily_loss_limit) * 100
-            
-            return {
-                "risk_phase": risk_phase.value,
-                "daily_loss_pct": daily_loss_pct,
-                "daily_risk_used": risk_used_pct,
-                "risk_used_pct": min(risk_used_pct, 100),
-                "risk_remaining_pct": max(100 - risk_used_pct, 0),
-                "trades_used": account_state.trades_today,
-                "trades_remaining": max(limits.max_trades_per_day - account_state.trades_today, 0),
-                "trades_left": max(limits.max_trades_per_day - account_state.trades_today, 0),
-                "max_trades": limits.max_trades_per_day,
-                "per_trade_risk": limits.per_trade_risk,
-                "consecutive_losses": account_state.consecutive_losses,
-                "status": risk_phase.value.replace('_', ' ').title(),
-                "warnings": self._get_current_warnings(account_state, limits)
-            }
-        except Exception as e:
-            self.logger.error(f"Error getting risk status: {e}")
-            return {
-                "risk_phase": "unknown",
-                "daily_loss_pct": 0,
-                "daily_risk_used": 0,
-                "risk_used_pct": 0,
-                "risk_remaining_pct": 100,
-                "trades_used": 0,
-                "trades_remaining": 5,
-                "trades_left": 5,
-                "max_trades": 5,
-                "per_trade_risk": 0.005,
-                "consecutive_losses": 0,
-                "status": "Unknown",
-                "warnings": ["System error"]
-            }
-    
-    def _get_current_warnings(self, account_state: AccountState, limits: RiskLimits) -> List[str]:
-        """Get current risk warnings"""
+    def _check_behavioral_patterns(self) -> Dict:
+        """Check for problematic behavioral patterns"""
         warnings = []
         
-        try:
-            daily_loss_pct = abs(account_state.daily_pnl) / account_state.starting_equity
+        # Check time of day (fatigue)
+        current_hour = datetime.now().hour
+        if current_hour >= 22 or current_hour <= 6:
+            warnings.append('🌙 Late night trading - higher risk of errors')
+            self.behavioral_flags['fatigue'] = True
             
-            if daily_loss_pct > 0.02:
-                warnings.append("Approaching daily loss limit")
+        # Check consecutive losses
+        if self.daily_stats['consecutive_losses'] >= 2:
+            warnings.append(f'📉 {self.daily_stats["consecutive_losses"]} consecutive losses - consider a break')
             
-            if account_state.consecutive_losses >= 2:
-                warnings.append("Multiple consecutive losses")
+        # Check rapid trading
+        if self._is_rapid_trading():
+            warnings.append('⚡ Rapid trading detected - slow down')
             
-            if account_state.trades_today >= limits.max_trades_per_day * 0.8:
-                warnings.append("Approaching trade limit")
-                
-        except Exception:
-            warnings.append("Unable to calculate warnings")
+        return {'warnings': warnings}
+    
+    def _check_revenge_trading(self) -> Dict:
+        """Detect revenge trading patterns"""
+        if not self.daily_stats['last_loss_time']:
+            return {'detected': False}
+            
+        time_since_loss = datetime.now() - self.daily_stats['last_loss_time']
         
-        return warnings
-
-# Factory function for integration
-def create_risk_enforcer() -> EnhancedRiskEnforcer:
-    """Factory function to create risk enforcer"""
-    return EnhancedRiskEnforcer()
-
-# Backwards compatibility alias
-RiskEnforcer = EnhancedRiskEnforcer
+        if time_since_loss.seconds < self.limits['revenge_trade_window'] * 60:
+            if self.daily_stats['consecutive_losses'] > 0:
+                return {
+                    'detected': True,
+                    'confidence': 0.8,
+                    'reason': 'Quick re-entry after loss'
+                }
+                
+        return {'detected': False}
+    
+    def _check_overconfidence(self) -> Dict:
+        """Detect overconfidence patterns"""
+        # Simple check: many trades in succession or after wins
+        if self.daily_stats['trades_count'] >= 4:
+            return {
+                'detected': True,
+                'confidence': 0.7,
+                'reason': 'High trade frequency'
+            }
+        return {'detected': False}
+    
+    def _is_rapid_trading(self) -> bool:
+        """Check if trading too rapidly"""
+        # Would check timestamps of recent trades
+        # Simplified for now
+        return False
+    
+    def _calculate_behavioral_score(self) -> int:
+        """Calculate overall behavioral score 0-100"""
+        score = 100
+        
+        # Deduct for flags
+        if self.behavioral_flags['revenge_trading']:
+            score -= 30
+        if self.behavioral_flags['overconfidence']:
+            score -= 20
+        if self.behavioral_flags['fatigue']:
+            score -= 15
+        if self.behavioral_flags['tilt']:
+            score -= 25
+            
+        # Deduct for violations
+        score -= len(self.daily_stats['violations']) * 10
+        
+        return max(0, score)
+    
+    def _calculate_risk_level(self) -> str:
+        """Calculate current risk level"""
+        score = self._calculate_behavioral_score()
+        
+        if score >= 80:
+            return 'low'
+        elif score >= 60:
+            return 'medium'
+        elif score >= 40:
+            return 'high'
+        else:
+            return 'critical'
+    
+    def update_trade_result(self, result: Dict):
+        """Update stats after a trade completes"""
+        self.daily_stats['trades_count'] += 1
+        self.daily_stats['total_pnl'] += result.get('pnl', 0)
+        
+        if result.get('pnl', 0) < 0:
+            self.daily_stats['losses_count'] += 1
+            self.daily_stats['consecutive_losses'] += 1
+            self.daily_stats['last_loss_time'] = datetime.now()
+            
+            # Trigger cooling period after significant loss
+            if abs(result.get('pnl', 0)) > 100:
+                self.daily_stats['cooling_until'] = (
+                    datetime.now() + timedelta(minutes=self.limits['cooling_period_minutes'])
+                )
+        else:
+            self.daily_stats['consecutive_losses'] = 0
+            
+    def reset_daily_stats(self):
+        """Reset daily statistics"""
+        self.daily_stats = {
+            'date': datetime.now().date(),
+            'trades_count': 0,
+            'total_pnl': 0,
+            'losses_count': 0,
+            'consecutive_losses': 0,
+            'last_loss_time': None,
+            'cooling_until': None,
+            'violations': []
+        }
+        
+        self.behavioral_flags = {
+            'revenge_trading': False,
+            'overconfidence': False,
+            'fatigue': False,
+            'tilt': False
+        }


### PR DESCRIPTION
## Summary
- add asynchronous PulseKernel orchestrator coordinating confluence scoring, risk checks, journaling, and publishing
- implement ConfluenceScorer wrapper that fuses SMC, Wyckoff, and technical analysis signals
- add simplified RiskEnforcer enforcing daily limits and behavioral safeguards
- provide configurable Pulse settings in pulse_config.yaml

## Testing
- `pytest` *(fails: TypeError: 'coroutine' object is not subscriptable; assert None is not None)*

------
https://chatgpt.com/codex/tasks/task_b_68bc56e0415883288444f8735d169aeb