### PR TITLE
Add MT5 deal filtering and API journal sync

### DIFF
--- a/mt5_bridge.py
+++ b/mt5_bridge.py
@@ -9,6 +9,11 @@ import json
 import MetaTrader5 as mt5
 import numpy as np
 import pandas as pd
+import pytz
+import requests
+
+# Timezone constants
+LONDON = pytz.timezone("Europe/London")
 
 
 class MT5Bridge:
@@ -49,16 +54,27 @@ class MT5Bridge:
         from_date = datetime.now() - timedelta(days=days_back)
         deals = mt5.history_deals_get(from_date, datetime.now())
 
-        if deals is None or len(deals) == 0:
+        if not deals:
             return pd.DataFrame()
 
-        df = pd.DataFrame(list(deals), columns=deals[0]._asdict().keys())
+        df = pd.DataFrame([d._asdict() for d in deals])
+
+        if 'time_msc' in df.columns:
+            df['time'] = pd.to_datetime(df['time_msc'], unit='ms', utc=True).dt.tz_convert(LONDON)
+        else:
+            df['time'] = pd.to_datetime(df['time'], unit='s', utc=True).dt.tz_convert(LONDON)
+
+        TRADE_TYPES = {mt5.DEAL_TYPE_BUY, mt5.DEAL_TYPE_SELL}
+        df = df[df['type'].isin(TRADE_TYPES)].copy()
+
+        df['net_profit'] = df['profit']
+        df['gross_profit'] = df['profit'] - df.get('commission', 0) - df.get('swap', 0)
+
         df = self._enrich_with_behavioral_data(df)
         return df
 
     def _enrich_with_behavioral_data(self, df: pd.DataFrame) -> pd.DataFrame:
         """Enrich trade history with behavioral analysis."""
-        df["time"] = pd.to_datetime(df["time"], unit="s")
         df = df.sort_values("time")
 
         df["is_win"] = df["profit"] > 0
@@ -236,6 +252,44 @@ class MT5Bridge:
             json.dump(journal, f, indent=2)
 
         return len(journal)
+
+    def sync_to_pulse_journal_api(self, base_url: str, token: str) -> int:
+        """Sync trade history to Pulse journal via REST API."""
+        df = self.get_real_trade_history()
+        if df.empty:
+            return 0
+
+        payload = [
+            {
+                "timestamp": trade["time"].isoformat(),
+                "ticket": int(trade["ticket"]),
+                "symbol": trade.get("symbol", "UNKNOWN"),
+                "volume": float(trade["volume"]),
+                "profit": float(trade["profit"]),
+                "flags": {
+                    k: bool(trade.get(k, False))
+                    for k in [
+                        "revenge_trade",
+                        "overconfidence",
+                        "fatigue_trade",
+                        "fomo_trade",
+                    ]
+                },
+                "risk_score": int(trade.get("behavioral_risk_score", 0)),
+            }
+            for _, trade in df.iterrows()
+        ]
+
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        url = f"{base_url.rstrip('/')}/api/pulse/journal/import"
+        try:
+            response = requests.post(url, json=payload, headers=headers, timeout=10)
+            response.raise_for_status()
+        except requests.RequestException as e:
+            print(f"Failed to sync journal to API: {e}")
+            return 0
+
+        return len(payload)
 
     def generate_weekly_review(self) -> Dict:
         """Generate weekly performance and behavioral review."""


### PR DESCRIPTION
## Summary
- Filter MT5 deal history to BUY/SELL types, prefer `time_msc` for timestamp precision, and compute net/gross profit fields
- Expose REST API write-through via new `sync_to_pulse_journal_api` helper

## Testing
- `pytest` *(fails: 'PulseKernel.on_frame' coroutine not awaited in several tests)*

------
https://chatgpt.com/codex/tasks/task_b_68bc5c1e15ec8328a74664c21f5ce2ca