### PR TITLE
Add FastAPI Pulse API service with Docker support

### DIFF
--- a/Dockerfile.pulse-api
+++ b/Dockerfile.pulse-api
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /srv/pulse-api
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential curl && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY pulse_kernel.py confluence_scorer.py risk_enforcer.py pulse_config.yaml ./
+COPY app ./app
+
+EXPOSE 8000
+CMD ["python", "app/main.py"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# Makes 'app' a package for imports.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,209 @@
+import os
+import json
+import uvicorn
+import logging
+from datetime import datetime
+from typing import List, Optional, Dict, Any
+
+from fastapi import FastAPI, Depends, HTTPException, Body, Query
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field, conlist, confloat
+
+try:
+    from pulse_kernel import PulseKernel
+except Exception as e:
+    raise RuntimeError(f"PulseKernel import failed: {e}")
+
+logger = logging.getLogger("pulse-api")
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format='%(asctime)s | %(levelname)s | %(name)s | %(message)s'
+)
+
+
+class Frame(BaseModel):
+    symbol: str = Field(..., examples=["EURUSD", "XAUUSD"])
+    ts: Optional[str] = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    df: Optional[Dict[str, Any]] = None
+    context: Optional[Dict[str, Any]] = None
+
+
+class ScoreResponse(BaseModel):
+    score: confloat(ge=0, le=100)
+    grade: str
+    components: Dict[str, float]
+    reasons: List[str]
+    details: Dict[str, Any] = {}
+
+
+class RiskCheckRequest(BaseModel):
+    symbol: str
+    intended_risk_fraction: confloat(ge=0, le=0.05) = 0.0
+    confluence_score: confloat(ge=0, le=100)
+    size_splits: int = 1
+
+
+class RiskCheckResponse(BaseModel):
+    allowed: bool
+    warnings: List[str]
+    details: Dict[str, Any]
+
+
+class JournalEntry(BaseModel):
+    timestamp: Optional[str] = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    type: str = Field(..., examples=["mt5_trade", "analysis", "note"])
+    data: Dict[str, Any]
+
+
+class JournalAppendResponse(BaseModel):
+    ok: bool
+    stored: int
+    last_key: str
+
+
+class JournalRecentResponse(BaseModel):
+    items: List[Dict[str, Any]]
+    total: int
+
+
+class TopSignal(BaseModel):
+    symbol: str
+    score: confloat(ge=0, le=100)
+    bias: Optional[str] = None
+    risk: Optional[str] = None
+    reasons: Optional[List[str]] = None
+
+
+class TopSignalsResponse(BaseModel):
+    items: conlist(TopSignal, min_items=0, max_items=25)
+
+
+class PulseRuntime:
+    _instance = None
+
+    def __init__(self):
+        self.kernel = PulseKernel(config_path=os.getenv("PULSE_CONFIG", "pulse_config.yaml"))
+        logger.info("PulseRuntime initialized")
+
+    @classmethod
+    def instance(cls):
+        if cls._instance is None:
+            cls._instance = PulseRuntime()
+        return cls._instance
+
+
+def get_runtime() -> PulseRuntime:
+    return PulseRuntime.instance()
+
+
+app = FastAPI(
+    title="Zanalytics Pulse API",
+    version=os.getenv("PULSE_API_VERSION", "1.0.0"),
+    docs_url="/pulse/docs",
+    redoc_url="/pulse/redoc",
+    openapi_url="/pulse/openapi.json",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=os.getenv("PULSE_CORS_ORIGINS", "*").split(","),
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/pulse/health")
+def health(rt: PulseRuntime = Depends(get_runtime)):
+    return {
+        "ok": True,
+        "system": "Zanalytics Pulse",
+        "status": rt.kernel.get_status(),
+        "time": datetime.utcnow().isoformat()
+    }
+
+
+@app.post("/pulse/score", response_model=ScoreResponse)
+async def score(frame: Frame, rt: PulseRuntime = Depends(get_runtime)):
+    result = await rt.kernel._calculate_confluence(frame.dict())
+    if not result or "score" not in result:
+        raise HTTPException(status_code=422, detail="Scoring failed")
+    return ScoreResponse(**result)
+
+
+@app.post("/pulse/risk", response_model=RiskCheckResponse)
+async def risk_check(payload: RiskCheckRequest, rt: PulseRuntime = Depends(get_runtime)):
+    signal = {
+        "symbol": payload.symbol,
+        "score": payload.confluence_score,
+        "size": float(payload.intended_risk_fraction),
+        "splits": int(payload.size_splits),
+    }
+    risk = await rt.kernel._enforce_risk({"score": payload.confluence_score})
+    out = {
+        "allowed": risk.get("allowed", False),
+        "warnings": risk.get("warnings", []),
+        "details": {
+            "remaining_trades": risk.get("remaining_trades"),
+            "remaining_risk": risk.get("remaining_risk"),
+            "cooling_active": risk.get("cooling_active", False),
+            "behavioral": rt.kernel._check_behavioral_state(),
+        }
+    }
+    return RiskCheckResponse(**out)
+
+
+@app.post("/pulse/journal", response_model=JournalAppendResponse)
+async def journal_append(entry: JournalEntry, rt: PulseRuntime = Depends(get_runtime)):
+    decision = {
+        "timestamp": entry.timestamp,
+        "type": entry.type,
+        "data": entry.data,
+    }
+    await rt.kernel._journal_decision(decision)
+    last_key = f"journal:{datetime.utcnow().strftime('%Y%m%d')}:{entry.timestamp}"
+    return JournalAppendResponse(ok=True, stored=1, last_key=last_key)
+
+
+@app.get("/pulse/journal/recent", response_model=JournalRecentResponse)
+def journal_recent(limit: int = Query(25, ge=1, le=200), rt: PulseRuntime = Depends(get_runtime)):
+    r = rt.kernel.redis_client
+    today_prefix = f"journal:{datetime.utcnow().strftime('%Y%m%d')}:"
+    keys = sorted([k.decode() for k in r.keys(f"{today_prefix}*")])[-limit:]
+    items = []
+    for k in keys:
+        raw = r.get(k)
+        if raw:
+            try:
+                items.append(json.loads(raw))
+            except Exception:
+                logger.warning("Malformed journal item at %s", k)
+    return JournalRecentResponse(items=items, total=len(items))
+
+
+@app.get("/pulse/signals/top", response_model=TopSignalsResponse)
+async def top_signals(symbols: Optional[str] = Query(default=None), rt: PulseRuntime = Depends(get_runtime)):
+    syms = [s.strip() for s in (symbols.split(",") if symbols else ["EURUSD", "GBPUSD", "XAUUSD"])]
+    scored: List[TopSignal] = []
+    for s in syms:
+        frame = Frame(symbol=s).dict()
+        result = await rt.kernel._calculate_confluence(frame)
+        if result and "score" in result:
+            scored.append(TopSignal(
+                symbol=s,
+                score=result["score"],
+                bias="BULL" if result["score"] >= 70 else "NEUTRAL",
+                risk="LOW" if result["score"] >= 80 else "MEDIUM",
+                reasons=result.get("reasons", [])[:3]
+            ))
+    scored.sort(key=lambda x: x.score, reverse=True)
+    return TopSignalsResponse(items=scored[: min(10, len(scored))])
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        "main:app",
+        host=os.getenv("HOST", "0.0.0.0"),
+        port=int(os.getenv("PORT", "8000")),
+        reload=bool(int(os.getenv("RELOAD", "0")))
+    )

--- a/docker-compose.pulse.yml
+++ b/docker-compose.pulse.yml
@@ -1,0 +1,40 @@
+version: "3.9"
+services:
+  pulse-api:
+    build:
+      context: .
+      dockerfile: Dockerfile.pulse-api
+    environment:
+      HOST: 0.0.0.0
+      PORT: 8000
+      PULSE_CONFIG: /srv/pulse-api/pulse_config.yaml
+      PULSE_CORS_ORIGINS: "http://localhost:8501,http://127.0.0.1:8501,*"
+      LOG_LEVEL: INFO
+      RELOAD: "0"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+    networks: [pulse-net]
+
+  streamlit:
+    image: python:3.11-slim
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: bash -lc "pip install -r requirements.txt && streamlit run pulse_ui_enhanced.py --server.port 8501 --server.address 0.0.0.0"
+    environment:
+      PULSE_API_BASE: "http://pulse-api:8000"
+    ports:
+      - "8501:8501"
+    depends_on:
+      - pulse-api
+    networks: [pulse-net]
+
+  redis:
+    image: redis:7.2-alpine
+    ports: ["6379:6379"]
+    networks: [pulse-net]
+
+networks:
+  pulse-net: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ python-dotenv==1.0.1
 pytz==2024.2
 pyarrow==15.0.2
 fastparquet>=2023.0
-redis==5.2.0
+redis==5.0.8
 requests==2.32.3
 six==1.16.0
 sqlparse==0.5.1
@@ -40,6 +40,11 @@ vine==5.1.0
 wcwidth==0.2.13
 whitenoise==6.7.0
 PyYAML==6.0.2
+
+fastapi==0.115.2
+uvicorn[standard]==0.30.6
+pydantic==1.10.15
+httpx==0.27.0
 
 streamlit>=1.28.0
 plotly>=5.17.0

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -1,0 +1,28 @@
+import asyncio
+import httpx
+from httpx import ASGITransport
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.main import app
+
+
+async def _call(method, url, **kw):
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        return await client.request(method, url, **kw)
+
+
+def test_health():
+    r = asyncio.run(_call("GET", "/pulse/health"))
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+
+def test_score_minimal():
+    r = asyncio.run(_call("POST", "/pulse/score", json={"symbol": "EURUSD"}))
+    assert r.status_code == 200
+    body = r.json()
+    assert "score" in body and "grade" in body
+


### PR DESCRIPTION
## Summary
- expose Pulse kernel via FastAPI with health, scoring, risk, journal and top-signal routes
- add Dockerfile and compose file for pulse-api, streamlit UI, and Redis
- include smoke tests and dependencies (FastAPI, uvicorn, pydantic, httpx)

## Testing
- `pip install fastapi==0.115.2 uvicorn[standard]==0.30.6 pydantic==1.10.15 httpx==0.27.0 redis==5.0.8`  
- `pip install scipy==1.13.1`  
- `pytest tests/test_api_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68bc6743b65c8328b64ca4efd585a3e6