### PR TITLE
docs: add pulse bot guide

### DIFF
--- a/services/pulse_bot/README.md
+++ b/services/pulse_bot/README.md
@@ -1,0 +1,30 @@
+# Pulse Telegram Bot
+
+This service exposes a Telegram bot for interacting with the Pulse trading kernel.
+
+## Environment Variables
+
+- **`TELEGRAM_BOT_TOKEN`** – Bot token obtained from BotFather.
+- **`TELEGRAM_CHAT_WHITELIST`** – Optional comma‑separated list of allowed chat IDs. When unset, all chats are accepted.
+- **`PULSE_CONFIG`** – Path to the Pulse configuration file; defaults to `pulse_config.yaml`.
+
+## Supported Commands
+
+| Command | Description |
+| --- | --- |
+| `/help` | Show available commands. |
+| `/status` | Display current risk and limit status. |
+| `/score <SYMBOL>` | Get current confluence score for the symbol. |
+| `/journal <TEXT>` | Append a note to the trading journal. |
+| `/stats` | Show today’s trading statistics. |
+| `/break <mins>` | Begin a voluntary cooling period. |
+
+## Version
+
+Built with [Aiogram 3.5.0](requirements.txt) and Python 3.11.
+
+## Runtime Sharing
+
+Both the bot and the REST API load the `PulseKernel` in their process. Sharing this
+runtime means commands and API calls operate on the same risk metrics, journal
+entries, and configuration, avoiding duplicated state or divergent trading logic.


### PR DESCRIPTION
## Summary
- Document Pulse Telegram bot environment variables and commands
- Note Aiogram version and runtime sharing with Pulse API

## Testing
- `pytest tests/test_pulse_api_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68bc6bb3a598832883d8bf2eb9debe1f