### PR TITLE
docs: add changelog with versioning policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.0.0] - 2025-09-06
+### Added
+- Initial release introducing FastAPI service and Telegram bot for real-time interaction.
+
+### Rationale
+- FastAPI exposes a modern, performant API to integrate analytical services and automate trading workflows.
+- Telegram bot provides a lightweight interface for notifications and remote control, improving accessibility for users on the go.
+
+## Versioning Policy
+- **MAJOR** version increments introduce incompatible API changes or significant redesigns.
+- **MINOR** version increments add functionality in a backwards-compatible manner.
+- **PATCH** version increments deliver backwards-compatible bug fixes.


### PR DESCRIPTION
## Summary
- document initial FastAPI and Telegram bot release in a new changelog
- outline semantic versioning policy for future updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bc6bb4e67083289993bd41bb66ee16