### PR TITLE
Add Kafka utility module and fix tick-to-bar Redis config

### DIFF
--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.3.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+    networks:
+      - traefik-public
+    restart: unless-stopped
+
+  kafka:
+    image: confluentinc/cp-kafka:7.3.0
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+    networks:
+      - traefik-public
+    restart: unless-stopped
+
+networks:
+  traefik-public:
+    external: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,4 @@ slowapi==0.1.8
 aioredis==2.0.1
 asyncpg==0.29.0
 fakeredis==2.23.2
+confluent-kafka==2.3.0

--- a/services/tick_to_bar.py
+++ b/services/tick_to_bar.py
@@ -4,8 +4,14 @@ import time
 import redis
 from datetime import datetime
 
+# Establish Redis connection from environment configuration.
+REDIS_HOST = os.getenv("REDIS_HOST", "redis")
+REDIS_URL = os.getenv("REDIS_URL", f"redis://{REDIS_HOST}:6379/0")
+r = redis.Redis.from_url(REDIS_URL)
+
 
 def _minute_floor(ts: float) -> float:
+    """Return the minute floor for a UNIX timestamp."""
     return (int(ts) // 60) * 60
 
 

--- a/utils/kafka_utils.py
+++ b/utils/kafka_utils.py
@@ -1,0 +1,38 @@
+from confluent_kafka import Producer, Consumer, KafkaError
+import os
+import json
+
+KAFKA_BOOTSTRAP_SERVERS = os.getenv('KAFKA_BOOTSTRAP_SERVERS', 'kafka:9092')
+TOPIC_TRADES = 'trades-stream'
+
+def produce_trade(data):
+    """Publish a trade event to Kafka."""
+    producer = Producer({'bootstrap.servers': KAFKA_BOOTSTRAP_SERVERS})
+    producer.produce(TOPIC_TRADES, key=str(data['timestamp']), value=json.dumps(data))
+    producer.flush()
+
+def consume_trades(callback):
+    """Consume trade events and invoke callback for each."""
+    consumer = Consumer({
+        'bootstrap.servers': KAFKA_BOOTSTRAP_SERVERS,
+        'group.id': 'enrichment-group',
+        'auto.offset.reset': 'earliest'
+    })
+    consumer.subscribe([TOPIC_TRADES])
+    try:
+        while True:
+            msg = consumer.poll(1.0)
+            if msg is None:
+                continue
+            if msg.error():
+                if msg.error().code() == KafkaError._PARTITION_EOF:
+                    continue
+                else:
+                    print(msg.error())
+                    break
+            data = json.loads(msg.value().decode('utf-8'))
+            callback(data)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        consumer.close()


### PR DESCRIPTION
## Summary
- add standalone docker-compose.kafka.yml with Kafka and Zookeeper
- introduce utils/kafka_utils for producing and consuming trade events
- fix tick-to-bar service to respect REDIS_URL/REDIS_HOST env vars
- include confluent-kafka dependency

## Testing
- `PYTHONPATH=. pytest tests/test_tick_to_enrich_flow.py`

------
https://chatgpt.com/codex/tasks/task_b_68bc97da6c788328aa1c77295b9cb2a9