### PR TITLE
feat: add Kafka journaling with retry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ aioredis==2.0.1
 asyncpg==0.29.0
 fakeredis==2.23.2
 confluent-kafka==2.5.0
+tenacity==8.2.3


### PR DESCRIPTION
## Summary
- integrate confluent-kafka Producer into `PulseKernel`
- add resilient Kafka send with retries and hybrid Redis journaling
- document new dependencies

## Testing
- `pytest` *(fails: No module named 'app.components')*

------
https://chatgpt.com/codex/tasks/task_b_68bc9e308bb88328ab8412f58d545297