### PR TITLE
feat: normalize position endpoints

### DIFF
--- a/backend/django/app/nexus/urls.py
+++ b/backend/django/app/nexus/urls.py
@@ -55,6 +55,7 @@ from .views import (
     StateSnapshotView,
 )
 from .views_positions import (
+    PositionsOpenView,
     PositionsCloseView,
     PositionsModifyView,
     PositionsHedgeView,
@@ -131,8 +132,8 @@ urlpatterns = [
     path('market/fetch', MarketFetchView.as_view(), name='market-fetch'),
     path('market/news/next', MarketNewsPublisherView.as_view(), name='market-news-next'),
     path('account/positions', PositionsProxyView.as_view(), name='account-positions'),
-    # Convenience alias: open a position via orders/market
-    path('positions/open', OrderMarketProxyView.as_view(), name='positions-open'),
+    # Open position
+    path('positions/open', PositionsOpenView.as_view(), name='positions-open'),
     # LLM-friendly aliases
     path('positions/close', PositionsCloseView.as_view(), name='positions-close'),
     path('positions/modify', PositionsModifyView.as_view(), name='positions-modify'),

--- a/docs/POSITIONS_AND_ORDERS.md
+++ b/docs/POSITIONS_AND_ORDERS.md
@@ -8,11 +8,14 @@ Overview
 
 Quick reference
 - Open: POST `/api/v1/positions/open` (alias → `/api/v1/orders/market`)
-  { symbol, volume, side, sl?, tp?, comment? }
+  { symbol, side, volume, sl?, tp?, comment? }
+  - Aliases accepted: `instrument`→symbol, `action`→side, `lots`/`qty`→volume
 - Close full/partial: POST `/api/v1/positions/close`
   { ticket, fraction? | volume? }
+  - Alias: `id`→ticket
 - Modify SL/TP: POST `/api/v1/positions/modify`
   { ticket, sl?, tp? }
+  - Alias: `id`→ticket
 - Hedge: POST `/api/v1/positions/hedge`
   { ticket, volume? }  (opposite side is inferred from the position)
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -286,6 +286,26 @@ paths:
                 fraction: { type: number, nullable: true, description: 0..1 }
       responses: { '200': { description: OK } }
 
+  /api/v1/positions/open:
+    post:
+      summary: Open a new market position (alias → orders/market)
+      operationId: postPositionsOpen
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [symbol, side, volume]
+              properties:
+                symbol: { type: string }
+                side: { type: string, enum: [buy, sell] }
+                volume: { type: number }
+                sl: { type: number, nullable: true }
+                tp: { type: number, nullable: true }
+      responses:
+        '200': { description: OK }
+
   /api/v1/positions/close:
     post:
       summary: Close full or partial position (alias → orders/close)


### PR DESCRIPTION
## Summary
- add PositionsOpenView with alias handling and validation
- accept ticket/id aliases and stricter checks for close and modify endpoints
- document aliases and expose open endpoint in OpenAPI spec

## Testing
- `pytest tests/test_api_smoke.py` *(fails: TypeError: conlist() got an unexpected keyword argument 'min_items')*

------
https://chatgpt.com/codex/tasks/task_b_68bf8c9cb6fc83289faa91f5a847671e