### PR TITLE
Fix donuts scope and robust trade diagnostics

### DIFF
--- a/dashboard/pages/24_Trades_Diagnostics.py
+++ b/dashboard/pages/24_Trades_Diagnostics.py
@@ -41,15 +41,13 @@ def _get_json(url: str, *, params: Dict[str, Any] | None = None, timeout: float 
 
 
 def _as_df(rows: List[Dict[str, Any]] | Any) -> pd.DataFrame:
-    """
-    Accepts either a list of row dicts or a dict payload that nests a list
-    under common keys like results/items/trades/history/data/rows.
+    """Accept list OR dict containers like {'results': [...]}, {'data': [...]}, {'items': [...]}, {'history': [...]}, or {'rows': [...]}.
     """
     try:
         if isinstance(rows, list):
             return pd.DataFrame(rows)
         if isinstance(rows, dict):
-            for key in ("results", "items", "trades", "history", "data", "rows"):
+            for key in ("results", "data", "items", "history", "rows"):
                 val = rows.get(key)
                 if isinstance(val, list):
                     return pd.DataFrame(val)
@@ -75,17 +73,35 @@ url_pos = api_url("api/v1/account/positions")
 db_trades = _get_json(url_db, params={"limit": int(limit)})
 mt5_trades = _get_json(
     url_mt5,
-    params={"source": "mt5", "date_from": date_from.isoformat(), "date_to": dt.date.today().isoformat()}
+    params={
+        "source": "mt5",
+        "date_from": date_from.isoformat(),
+        "date_to": dt.date.today().isoformat(),
+        "limit": int(limit),
+    },
 )
 positions = _get_json(url_pos)
 
 # Fallback: some backends expect 'provider=mt5' instead of 'source=mt5'
-if (isinstance(mt5_trades, dict) and not _as_df(mt5_trades).shape[0]):
-    mt5_trades = _get_json(url_mt5, params={"provider": "mt5", "date_from": date_from.isoformat()})
+if isinstance(mt5_trades, dict) and not _as_df(mt5_trades).shape[0]:
+    mt5_trades = _get_json(
+        url_mt5,
+        params={
+            "provider": "mt5",
+            "date_from": date_from.isoformat(),
+            "date_to": dt.date.today().isoformat(),
+            "limit": int(limit),
+        },
+    )
 
 df_db = _as_df(db_trades)
 df_mt5 = _as_df(mt5_trades)
 df_pos = _as_df(positions)
+
+# Surface any API errors
+for label, payload in (("DB Trades", db_trades), ("MT5 History", mt5_trades), ("Positions", positions)):
+    if isinstance(payload, dict) and "error" in payload:
+        st.warning(f"{label} error: {payload.get('error')} — {payload.get('url','')}")
 
 
 def _normalize_cols(df: pd.DataFrame, cols: List[str]) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- Hoist shared session vitals in Pulse Pro so both donuts reference the same variables and handle risk-used safely
- Improve Trades Diagnostics panel: unwrap nested responses, request MT5 window with limit, and surface API errors

## Testing
- `pytest` *(fails: TypeError: conlist() got an unexpected keyword argument 'min_items')*


------
https://chatgpt.com/codex/tasks/task_b_68bf8da988508328ad15fcc193700bf2