### PR TITLE
Add position modify endpoints and MT5 bridge adapter

### DIFF
--- a/backend/django/app/nexus/urls.py
+++ b/backend/django/app/nexus/urls.py
@@ -58,6 +58,7 @@ from .views_positions import (
     PositionsOpenView,
     PositionsCloseView,
     PositionsModifyView,
+    PositionsModifyByTicketView,
     PositionsHedgeView,
 )
 from .playbook_stub_views import (
@@ -137,6 +138,7 @@ urlpatterns = [
     # LLM-friendly aliases
     path('positions/close', PositionsCloseView.as_view(), name='positions-close'),
     path('positions/modify', PositionsModifyView.as_view(), name='positions-modify'),
+    path('positions/<int:ticket>/modify', PositionsModifyByTicketView.as_view(), name='positions-modify-ticket'),
     path('positions/hedge', PositionsHedgeView.as_view(), name='positions-hedge'),
     path('account/info', AccountInfoView.as_view(), name='account-info'),
     path('journal/append', JournalAppendView.as_view(), name='journal-append'),

--- a/backend/django/app/nexus/views.py
+++ b/backend/django/app/nexus/views.py
@@ -1552,14 +1552,17 @@ class ActionsQueryView(views.APIView):
             if typ == 'position_modify':
                 # { ticket, sl?, tp? }
                 try:
-                    from .orders_service import modify_sl_tp
+                    from bridge.mt5 import modify_position
                 except Exception:
                     return Response({'error': 'service_unavailable'}, status=503)
                 ticket = payload.get('ticket')
                 if ticket is None:
                     return Response({'error': 'ticket required'}, status=400)
-                ok, data = modify_sl_tp(int(ticket), sl=payload.get('sl'), tp=payload.get('tp'),
-                                        idempotency_key=request.headers.get('X-Idempotency-Key'))
+                sl = payload.get('sl')
+                tp = payload.get('tp')
+                if sl is None and tp is None:
+                    return Response({'error': 'sl or tp required'}, status=400)
+                ok, data = modify_position(int(ticket), sl=sl, tp=tp)
                 return Response(data, status=200 if ok else 400)
             if typ == 'position_hedge':
                 # { ticket, volume? }

--- a/bridge/mt5.py
+++ b/bridge/mt5.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Tuple, Optional
+
+import requests
+
+DJANGO_INTERNAL_BASE = os.environ.get("DJANGO_INTERNAL_BASE", "http://django:8000").rstrip("/")
+
+
+def modify_position(ticket: int, sl: Optional[float] = None, tp: Optional[float] = None) -> Tuple[bool, Dict[str, Any]]:
+    """Modify SL/TP for a position via the MT5 bridge.
+
+    Returns (ok, result) where ok indicates HTTP 2xx from the bridge.
+    Fields with value ``None`` are omitted to keep existing broker values.
+    """
+    payload: Dict[str, Any] = {"ticket": int(ticket)}
+    if sl is not None:
+        payload["sl"] = float(sl)
+    if tp is not None:
+        payload["tp"] = float(tp)
+    url = f"{DJANGO_INTERNAL_BASE}/api/v1/orders/modify"
+    try:
+        r = requests.post(url, json=payload, timeout=10)
+    except Exception as e:
+        return False, {"error": str(e)}
+    ok = 200 <= r.status_code < 300
+    try:
+        body = r.json()
+    except Exception:
+        body = {"status": r.status_code, "text": r.text}
+    return ok, (body if ok else {"error": body, "status": r.status_code})

--- a/docs/POSITIONS_AND_ORDERS.md
+++ b/docs/POSITIONS_AND_ORDERS.md
@@ -13,8 +13,8 @@ Quick reference
 - Close full/partial: POST `/api/v1/positions/close`
   { ticket, fraction? | volume? }
   - Alias: `id`→ticket
-- Modify SL/TP: POST `/api/v1/positions/modify`
-  { ticket, sl?, tp? }
+- Modify SL/TP: POST `/api/v1/positions/modify` or `/api/v1/positions/<ticket>/modify`
+  { ticket?, sl?, tp? }
   - Alias: `id`→ticket
 - Hedge: POST `/api/v1/positions/hedge`
   { ticket, volume? }  (opposite side is inferred from the position)
@@ -48,6 +48,11 @@ Examples
   curl -sX POST "$DJANGO/api/v1/positions/modify" \
     -H 'Content-Type: application/json' \
     -d '{"ticket":302402468,"sl":3625}'
+
+- Modify TP via path
+  curl -sX POST "$DJANGO/api/v1/positions/302402468/modify" \
+    -H 'Content-Type: application/json' \
+    -d '{"tp":3625}'
 
 - Hedge full (uses current position volume)
   curl -sX POST "$DJANGO/api/v1/positions/hedge" \

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -342,6 +342,27 @@ paths:
       responses:
         '200': { description: OK }
 
+  /api/v1/positions/{ticket}/modify:
+    post:
+      summary: Modify SL/TP for an existing position by ticket in path
+      operationId: postPositionsModifyByTicket
+      parameters:
+        - in: path
+          name: ticket
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sl: { type: number, nullable: true }
+                tp: { type: number, nullable: true }
+      responses:
+        '200': { description: OK }
+
   /api/v1/positions/hedge:
     post:
       summary: Open opposite-side hedge order for a position


### PR DESCRIPTION
## Summary
- add MT5 bridge adapter with `modify_position`
- expose `/api/v1/positions/<ticket>/modify` alongside existing modify endpoint
- handle `position_modify` in actions bus with SL/TP validation

## Testing
- `pytest -q` *(fails: conlist() got an unexpected keyword argument 'min_items'; ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68bfa2cf696083288a3924f14ca5b09e