### PR TITLE
Add pulse analytics URL alias

### DIFF
--- a/backend/django/app/nexus/pulse/analytics_urls.py
+++ b/backend/django/app/nexus/pulse/analytics_urls.py
@@ -1,0 +1,16 @@
+from django.urls import path
+from .views import (
+    TradesQuality,
+    TradesSummary,
+    TradesEfficiency,
+    TradesBuckets,
+    TradesSetups,
+)
+
+urlpatterns = [
+    path('trades/quality', TradesQuality.as_view(), name='analytics-trades-quality'),
+    path('trades/summary', TradesSummary.as_view(), name='analytics-trades-summary'),
+    path('trades/efficiency', TradesEfficiency.as_view(), name='analytics-trades-efficiency'),
+    path('trades/buckets', TradesBuckets.as_view(), name='analytics-trades-buckets'),
+    path('trades/setups', TradesSetups.as_view(), name='analytics-trades-setups'),
+]

--- a/backend/django/app/nexus/pulse/urls.py
+++ b/backend/django/app/nexus/pulse/urls.py
@@ -1,8 +1,12 @@
 from django.urls import path
 from .views import (
-    PulseStatus, PulseDetail, PulseWeights, PulseGateHits, BarsEnriched, YFBars,
+    PulseStatus,
+    PulseDetail,
+    PulseWeights,
+    PulseGateHits,
+    BarsEnriched,
+    YFBars,
     TradeQualityDist,
-    TradesQuality, TradesSummary, TradesEfficiency, TradesBuckets, TradesSetups,
     TelegramHealth,
 )
 
@@ -14,12 +18,6 @@ urlpatterns = [
     path('feed/bars-enriched', BarsEnriched.as_view(), name='bars-enriched'),
     path('feed/yf-bars', YFBars.as_view(), name='yf-bars'),
     path('feed/trade-quality', TradeQualityDist.as_view(), name='trade-quality'),
-    # Analytics (phase 1)
-    path('analytics/trades/quality', TradesQuality.as_view(), name='analytics-trades-quality'),
-    path('analytics/trades/summary', TradesSummary.as_view(), name='analytics-trades-summary'),
-    path('analytics/trades/efficiency', TradesEfficiency.as_view(), name='analytics-trades-efficiency'),
-    path('analytics/trades/buckets', TradesBuckets.as_view(), name='analytics-trades-buckets'),
-    path('analytics/trades/setups', TradesSetups.as_view(), name='analytics-trades-setups'),
     # Health
     path('health/telegram', TelegramHealth.as_view(), name='telegram-health'),
 ]

--- a/backend/django/app/nexus/urls.py
+++ b/backend/django/app/nexus/urls.py
@@ -161,6 +161,7 @@ urlpatterns = [
     path('positions/<int:ticket>/protect', PositionProtectOptionsView.as_view(), name='position-protect-options'),
     # Include pulse module endpoints
     path('', include('app.nexus.pulse.urls')),
+    path('analytics/', include('app.nexus.pulse.analytics_urls')),
     # User prefs (unauthenticated, minimal)
     path('user/prefs', UserPrefsView.as_view(), name='user-prefs'),
     # Playbook stubs

--- a/backend/django/app/urls.py
+++ b/backend/django/app/urls.py
@@ -15,6 +15,8 @@ urlpatterns = [
 
     # v1 api
     path('api/v1/', include('app.nexus.urls')),
+    # Legacy pulse analytics alias
+    path('api/pulse/analytics/', include('app.nexus.pulse.analytics_urls')),
 
     # Wyckoff endpoints
     path('api/pulse/wyckoff/score', wyckoff_score, name='wyckoff-score'),


### PR DESCRIPTION
## Summary
- add dedicated analytics urlconf
- expose `/api/pulse/analytics/...` as alias to `/api/v1/analytics/...`

## Testing
- `pytest -q` *(fails: TypeError: conlist() got an unexpected keyword argument 'min_items')*

------
https://chatgpt.com/codex/tasks/task_b_68c0068197fc8328847f5260925f8586