### PR TITLE
Set MT5 API URL and add history proxy endpoints

### DIFF
--- a/backend/django/app/nexus/urls.py
+++ b/backend/django/app/nexus/urls.py
@@ -53,6 +53,8 @@ from .views import (
     PositionProtectOptionsView,
     UserPrefsView,
     StateSnapshotView,
+    HistoryDealsProxyView,
+    HistoryOrdersProxyView,
 )
 from .views_positions import (
     PositionsOpenView,
@@ -128,6 +130,8 @@ urlpatterns = [
     path('profit-horizon', ProfitHorizonView.as_view(), name='profit-horizon'),
     path('trades/history', TradeHistoryView.as_view(), name='trades-history'),
     path('trades/recent', TradesRecentView.as_view(), name='trades-recent'),
+    path('history_deals_get', HistoryDealsProxyView.as_view(), name='history-deals-get'),
+    path('history_orders_get', HistoryOrdersProxyView.as_view(), name='history-orders-get'),
     path('mirror/state', MirrorStateView.as_view(), name='mirror-state'),
     path('market/mini', MarketMiniView.as_view(), name='market-mini'),
     path('market/fetch', MarketFetchView.as_view(), name='market-fetch'),

--- a/backend/django/app/nexus/views.py
+++ b/backend/django/app/nexus/views.py
@@ -3196,6 +3196,50 @@ class UserPrefsView(views.APIView):
             return Response({'error': str(e)}, status=500)
 
 
+class HistoryDealsProxyView(views.APIView):
+    """Proxy MT5 history_deals_get endpoint."""
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        base = (
+            os.getenv("MT5_URL")
+            or os.getenv("MT5_API_URL")
+            or "http://mt5:5000"
+        )
+        try:
+            r = requests.get(
+                f"{str(base).rstrip('/')}/history_deals_get",
+                params=request.GET,
+                timeout=5,
+            )
+            r.raise_for_status()
+            return Response(r.json())
+        except Exception as e:
+            return Response({"error": str(e)}, status=502)
+
+
+class HistoryOrdersProxyView(views.APIView):
+    """Proxy MT5 history_orders_get endpoint."""
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        base = (
+            os.getenv("MT5_URL")
+            or os.getenv("MT5_API_URL")
+            or "http://mt5:5000"
+        )
+        try:
+            r = requests.get(
+                f"{str(base).rstrip('/')}/history_orders_get",
+                params=request.GET,
+                timeout=5,
+            )
+            r.raise_for_status()
+            return Response(r.json())
+        except Exception as e:
+            return Response({"error": str(e)}, status=502)
+
+
 class PulseStatusView(views.APIView):
     """Return gate statuses for the PULSE Predictive Flow Framework.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,6 +206,7 @@ services:
       - ALERTS_SCORE_HI=90
       - ALERTS_TOXICITY_LIMIT=0.30
       - ALERTS_DD_INTRADAY_WARN=0.025
+      - MT5_API_URL=http://mt5:5000
       # Avoid overriding secret key with empty value; single definition above is sufficient
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary
- expose MT5_API_URL in Django container
- proxy MT5 history_deals_get and history_orders_get through Django

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus'; conlist() unexpected kwarg)*
- `curl -fsS http://mt5:5000/history_deals_get` *(fails: 503)*
- `curl -fsS http://mt5:5000/history_orders_get` *(fails: 503)*

------
https://chatgpt.com/codex/tasks/task_b_68c007a6641c83289841eba6c13f2b7d