### PR TITLE
Handle missing bar data in score_peek

### DIFF
--- a/backend/django/pulse_api/tests.py
+++ b/backend/django/pulse_api/tests.py
@@ -1,3 +1,40 @@
-from django.test import TestCase
+import os
+import json
 
-# Create your tests here.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
+os.environ.setdefault("DJANGO_SECRET_KEY", "test-secret")
+import django
+django.setup()
+from django.conf import settings
+settings.ALLOWED_HOSTS.append("testserver")
+from django.test import SimpleTestCase
+from django.urls import reverse
+
+
+class ScorePeekTests(SimpleTestCase):
+    def test_score_peek_with_bars(self):
+        bars = [
+            {"open": 1.0, "high": 1.5, "low": 0.5, "close": 1.2},
+            {"open": 1.2, "high": 1.7, "low": 0.8, "close": 1.4},
+            {"open": 1.4, "high": 1.6, "low": 1.1, "close": 1.3},
+        ]
+        resp = self.client.post(
+            reverse("pulse_score_peek"),
+            data=json.dumps({"bars": bars}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("score", data)
+        self.assertIn("timestamp", data)
+
+    def test_score_peek_missing_bars(self):
+        resp = self.client.post(
+            reverse("pulse_score_peek"),
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400)
+        data = resp.json()
+        self.assertIn("error", data)
+

--- a/backend/django/pulse_api/views.py
+++ b/backend/django/pulse_api/views.py
@@ -88,9 +88,15 @@ def score_peek(request):
     """Get current confluence score with explainable reasons"""
     try:
         payload = json.loads(request.body or "{}")
-        bars = payload.get("bars", [])
+        bars = payload.get("bars")
         if not bars:
-            return HttpResponseBadRequest("'bars' field required")
+            return JsonResponse(
+                {
+                    "error": "'bars' field required",
+                    "timestamp": datetime.now().isoformat(),
+                },
+                status=400,
+            )
 
         df = pd.DataFrame(bars)
         result = compute_confluence(df)


### PR DESCRIPTION
## Summary
- return structured JSON error when `bars` are absent in `score_peek`
- add unit tests for `score_peek` covering valid input and missing bars

## Testing
- `pytest backend/django/pulse_api/tests.py`


------
https://chatgpt.com/codex/tasks/task_b_68c008e2624c8328b720192aa399017d