### PR TITLE
Improve bars enrichment error handling and tests

### DIFF
--- a/backend/django/app/nexus/pulse/service.py
+++ b/backend/django/app/nexus/pulse/service.py
@@ -4,7 +4,11 @@ import json
 from typing import Dict, Any, Optional
 import os
 import json
-import pandas as pd
+
+try:  # pandas is optional at runtime
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover - handled gracefully when missing
+    pd = None  # type: ignore
 
 from django.conf import settings
 
@@ -26,7 +30,9 @@ from .gates import KafkaJournalEngine as _KafkaJournalEngine
 import time as _time
 
 
-def _normalize_bars(df: pd.DataFrame | None) -> pd.DataFrame | None:
+def _normalize_bars(df: "pd.DataFrame | None") -> "pd.DataFrame | None":
+    if pd is None:
+        raise ImportError("pandas library is required for bar normalization")
     if df is None or not isinstance(df, pd.DataFrame) or df.empty:
         return None
     # Ensure expected columns
@@ -63,7 +69,11 @@ def _load_minute_data(symbol: str) -> Dict[str, Any]:
     """Load H4/H1/M15/M1 bars for a symbol from DB; fallback to bridge.
 
     Returns dict of pandas DataFrames with columns: timestamp, open, high, low, close, volume.
+    Raises ImportError if pandas is not installed.
     """
+    if pd is None:
+        raise ImportError("pandas library is required to load minute bar data")
+
     out: Dict[str, Any] = {"H4": None, "H1": None, "M15": None, "M1": None}
     tf_map = {
         'H4': ('H4', MT5Timeframe.H4, 300),

--- a/tests/test_bars_enriched_endpoint.py
+++ b/tests/test_bars_enriched_endpoint.py
@@ -1,0 +1,89 @@
+import os
+import sys
+from pathlib import Path
+import types
+import importlib
+import django
+from django.test import Client
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend" / "django"))
+sys.path.insert(0, str(ROOT))
+
+app_stub = types.ModuleType("app")
+app_stub.__path__ = [str(ROOT / "backend" / "django" / "app")]
+sys.modules.setdefault("app", app_stub)
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.django.app.test_settings")
+django.setup()
+from django.conf import settings
+settings.ALLOWED_HOSTS.append("testserver")
+
+# Ensure real pandas is available for enrichment
+sys.modules.pop("pandas", None)
+import pandas as pd
+pulse_service = importlib.import_module("app.nexus.pulse.service")
+pulse_views = importlib.import_module("app.nexus.pulse.views")
+importlib.reload(pulse_service)
+importlib.reload(pulse_views)
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+def _sample_loader(symbol):
+    dates = pd.date_range("2023-01-01", periods=60, freq="T")
+    base = {
+        "timestamp": dates,
+        "open": range(60),
+        "high": range(1, 61),
+        "low": range(0, 60),
+        "close": range(1, 61),
+        "volume": [100] * 60,
+    }
+    df = pd.DataFrame(base)
+    return {"M15": df, "M1": df, "H1": df, "H4": df}
+
+
+def test_bars_enriched_with_enrichment(client, monkeypatch):
+    monkeypatch.setattr(pulse_service, "_load_minute_data", _sample_loader)
+    monkeypatch.setattr(pulse_views, "_load_minute_data", _sample_loader)
+    response = client.get(
+        "/api/v1/feed/bars-enriched",
+        {"symbol": "EURUSD", "timeframe": "M15", "limit": 5},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 5
+    assert data["items"][-1]["sma20"] is not None
+
+
+def test_bars_enriched_without_enrichment(client, monkeypatch):
+    monkeypatch.setattr(pulse_service, "_load_minute_data", _sample_loader)
+    monkeypatch.setattr(pulse_views, "_load_minute_data", _sample_loader)
+    response = client.get(
+        "/api/v1/feed/bars-enriched",
+        {"symbol": "EURUSD", "timeframe": "M15", "limit": 5, "enrich": "false"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 5
+    assert data["items"][-1]["sma20"] is None
+
+
+def test_bars_enriched_missing_pandas(client, monkeypatch):
+    def _broken_loader(symbol):
+        raise ImportError("pandas missing")
+
+    monkeypatch.setattr(pulse_service, "_load_minute_data", _broken_loader)
+    monkeypatch.setattr(pulse_views, "_load_minute_data", _broken_loader)
+    response = client.get(
+        "/api/v1/feed/bars-enriched",
+        {"symbol": "EURUSD", "timeframe": "M15"},
+    )
+    assert response.status_code == 503
+    assert "pandas" in response.json().get("error", "")
+


### PR DESCRIPTION
## Summary
- handle missing pandas or data in `_load_minute_data` and `/api/v1/feed/bars-enriched`, returning 503 with helpful messages
- guard enrichment serialization against NaN values
- add integration tests for `/api/v1/feed/bars-enriched` with and without enrichment and when pandas is missing

## Testing
- `pytest tests/test_bars_enriched_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68c008e9c1448328bb7d701447d2e0ff