### PR TITLE
docs: clarify MT5 history endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,14 @@ This modular design facilitates secure separation of concerns, easy extensibilit
 
 ## MT5 service vs. Django API
 
-History and order endpoints are served by the MT5 bridge rather than the Django API, so they must be accessed via `MT5_API_URL`.
+The history endpoints `/history_deals_get` and `/history_orders_get` are provided only by the MT5 bridge. They are **not** available under the Django domain, so requests must target `MT5_API_URL` directly.
 
 ```bash
 curl "$MT5_API_URL/history_deals_get"
+curl "$MT5_API_URL/history_orders_get"
 ```
+
+These paths do not exist at `$DJANGO_API_URL` or any Django prefix.
 
 See [backend/mt5/app/routes/history.py](backend/mt5/app/routes/history.py) for details.
 


### PR DESCRIPTION
## Summary
- Clarify that `/history_deals_get` and `/history_orders_get` are only served by the MT5 bridge
- Show example requests using `MT5_API_URL`
- Note that these history paths do not exist under the Django domain

## Testing
- `pytest` *(fails: conlist() got an unexpected keyword argument 'min_items')*

------
https://chatgpt.com/codex/tasks/task_b_68c011e2de98832890b15eaab68c32d8