### PR TITLE
chore: update MT5 API URL port for django

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,7 +206,7 @@ services:
       - ALERTS_SCORE_HI=90
       - ALERTS_TOXICITY_LIMIT=0.30
       - ALERTS_DD_INTRADAY_WARN=0.025
-      - MT5_API_URL=http://mt5:5000
+      - MT5_API_URL=http://mt5:5001
       # Avoid overriding secret key with empty value; single definition above is sufficient
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary
- point Django at MT5 API on port 5001 instead of 5000

## Testing
- `python - <<'PY'
import yaml,sys
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `docker-compose up -d` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_b_68c011bf5f808328a91da29b8d0fff5b