### PR TITLE
chore: disable mt5 service port bindings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,9 +77,9 @@ services:
     volumes:
       - ./config:/config
       - ./mt5_gateway:/opt/mt5_gateway:ro
-    ports:
-      - "8000:8000"
-      - "5001:5001"
+    # ports:
+    #   - "8000:8000"
+    #   - "5001:5001"
     networks:
       - traefik-public
       - default


### PR DESCRIPTION
## Summary
- rely on Traefik for external access by disabling mt5 direct port mappings

## Testing
- `python - <<'PY' ...` (YAML parsed successfully)
- `pytest -q` *(fails: conlist() unexpected keyword argument 'min_items'; ModuleNotFoundError: app.nexus; RuntimeError: populate() isn't reentrant)*
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_b_68c01336d2548328bffe8dbde0fe05e6