### PR TITLE
Proxy MT5 history endpoints through Django and hide bridge ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,14 +109,14 @@ This modular design facilitates secure separation of concerns, easy extensibilit
 
 ## MT5 service vs. Django API
 
-The history endpoints `/history_deals_get` and `/history_orders_get` are provided only by the MT5 bridge. They are **not** available under the Django domain, so requests must target `MT5_API_URL` directly.
+The MT5 bridge hosts its own REST interface. Django exposes proxies for the MT5 history endpoints, but they simply forward to the MT5 service. To avoid confusion, always point history requests to `MT5_API_URL`.
 
 ```bash
 curl "$MT5_API_URL/history_deals_get"
 curl "$MT5_API_URL/history_orders_get"
 ```
 
-These paths do not exist at `$DJANGO_API_URL` or any Django prefix.
+Directly hitting `$DJANGO_API_URL/history_deals_get` or `$DJANGO_API_URL/history_orders_get` will proxy the call, but the upstream service is still the MT5 bridge.
 
 See [backend/mt5/app/routes/history.py](backend/mt5/app/routes/history.py) for details.
 

--- a/backend/django/app/urls.py
+++ b/backend/django/app/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
 from django.http import JsonResponse
-from app.nexus.views import Healthz
+from app.nexus.views import Healthz, HistoryDealsProxyView, HistoryOrdersProxyView
 from .api.views_wyckoff import wyckoff_score, wyckoff_health
 from app import pulse_views
 from .whisper_views import whisper_stream, whisper_ack, whisper_act, whisper_log
@@ -12,6 +12,10 @@ def health(request):
 urlpatterns = [
     # Admin & base
     path('admin/', admin.site.urls),
+
+    # MT5 history proxies (forward to MT5_API_URL)
+    path('history_deals_get', HistoryDealsProxyView.as_view(), name='history-deals-get'),
+    path('history_orders_get', HistoryOrdersProxyView.as_view(), name='history-orders-get'),
 
     # v1 api
     path('api/v1/', include('app.nexus.urls')),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,9 +77,6 @@ services:
     volumes:
       - ./config:/config
       - ./mt5_gateway:/opt/mt5_gateway:ro
-    ports:
-      - "8000:8000"
-      - "5001:5001"
     networks:
       - traefik-public
       - default

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -76,9 +76,6 @@ services:
     container_name: mt5
     volumes:
       - ./config:/config
-    ports:
-      - "8000:8000"
-      - "5001:5001"
     networks:
       - traefik-public
       - default
@@ -202,6 +199,7 @@ services:
       - ALERTS_SCORE_HI=90
       - ALERTS_TOXICITY_LIMIT=0.30
       - ALERTS_DD_INTRADAY_WARN=0.025
+      - MT5_API_URL=http://mt5:5001
       - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary
- Stop publishing the MT5 bridge ports so the service is only reachable on the internal Docker network
- Forward `/history_deals_get` and `/history_orders_get` through Django to the MT5 bridge
- Document MT5 vs. Django API usage, recommending direct calls to the MT5 service

## Testing
- `pytest tests/test_history_mt5_proxies.py`

------
https://chatgpt.com/codex/tasks/task_b_68c0113ba63883289f975b631b6e7154