### PR TITLE
Pulse Dashboard: live MT5 + Actions wiring

### DIFF
--- a/dashboard/config/dashboard_metrics_summary.yaml
+++ b/dashboard/config/dashboard_metrics_summary.yaml
@@ -1,0 +1,24 @@
+session_metrics:
+  start_of_day_balance: true
+  current_equity: true
+  daily_risk_allowance_percent: true
+  current_risk_used_percent: true
+  session_time_remaining: true
+
+trade_metrics:
+  unrealized_pnl: true
+  time_in_trade: true
+  exposure_percent: true
+  max_adverse_excursion: true
+
+behavioral_metrics:
+  composite_posture_score: true
+  patience_index: true
+  conviction_accuracy: true
+  profit_efficiency: true
+  overtrading_alert: true
+
+future_signals:
+  next_news_release: true
+  context_alerts: true
+  whisperer_rating: true

--- a/dashboard/config/dashboard_prompt.txt
+++ b/dashboard/config/dashboard_prompt.txt
@@ -1,0 +1,1 @@
+Focus on high-conviction setups and manage risk diligently.

--- a/dashboard/pages/01_Pulse_Dashboard.py
+++ b/dashboard/pages/01_Pulse_Dashboard.py
@@ -1,0 +1,273 @@
+import os, json, time, uuid, math, datetime as dt
+from typing import Any, Dict, List
+import requests
+import yaml
+import streamlit as st
+import plotly.graph_objects as go
+
+# ---------------- Config ----------------
+METRICS_PATH = os.getenv('DASH_METRICS_PATH', 'dashboard/config/dashboard_metrics_summary.yaml')
+PROMPT_PATH  = os.getenv('DASH_PROMPT_PATH',  'dashboard/config/dashboard_prompt.txt')
+
+MT5_URL     = os.getenv('MT5_URL', 'http://mt5:5001')
+DJANGO_URL  = os.getenv('DJANGO_API_URL', 'http://django:8000')
+DJANGO_PREF = os.getenv('DJANGO_API_PREFIX', '/api/v1')
+
+BRIDGE_TOKEN = os.getenv('BRIDGE_TOKEN')
+GATEWAY_HEADERS = {'X-Bridge-Token': BRIDGE_TOKEN} if BRIDGE_TOKEN else {}
+ACTIONS_URL = f"{DJANGO_URL}{DJANGO_PREF}/actions/query"
+
+# ---------------- Utils ----------------
+@st.cache_data(ttl=5.0)
+def load_yaml(path: str) -> Dict[str, Any]:
+    with open(path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f) or {}
+
+@st.cache_data(ttl=5.0)
+def load_prompt(path: str) -> str:
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return ''
+
+def get_json(url: str, headers=None, timeout=3):
+    try:
+        r = requests.get(url, headers=headers or {}, timeout=timeout)
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return None
+
+def post_actions(body: Dict[str, Any], idempotency_key: str | None = None, timeout=5):
+    headers = {'Content-Type': 'application/json'}
+    if idempotency_key:
+        headers['X-Idempotency-Key'] = idempotency_key
+    try:
+        r = requests.post(ACTIONS_URL, json=body, headers=headers, timeout=timeout)
+        ok = r.ok
+        data = None
+        try:
+            data = r.json()
+        except Exception:
+            data = {'text': r.text}
+        return ok, data
+    except Exception as e:
+        return False, {'error': str(e)}
+
+def donut(value: float, minv: float, maxv: float, label: str, unit: str = '', color='#2dd4bf'):
+    value = max(min(value, maxv), minv)
+    filled = value - minv
+    total = max(maxv - minv, 1.0)
+    empty = max(total - filled, 0.0)
+    fig = go.Figure(go.Pie(
+        values=[filled, empty],
+        hole=0.75,
+        sort=False,
+        marker=dict(colors=[color, '#e5e7eb']),
+        textinfo='none'
+    ))
+    fig.update_layout(
+        margin=dict(l=0, r=0, t=0, b=0),
+        showlegend=False,
+        annotations=[
+            dict(text=f"{value:.0f}{unit}", x=0.5, y=0.5, font_size=18, showarrow=False),
+            dict(text=label, x=0.5, y=0.24, font_size=12, showarrow=False, font_color='#6b7280'),
+        ],
+    )
+    st.plotly_chart(fig, use_container_width=True, config={'displayModeBar': False})
+
+def chip(text: str, kind: str = 'neutral'):
+    bg = {'good': '#dcfce7', 'warn': '#fef9c3', 'bad': '#fee2e2', 'neutral': '#f3f4f6'}.get(kind, '#f3f4f6')
+    color = {'good': '#166534', 'warn': '#854d0e', 'bad': '#991b1b', 'neutral': '#374151'}.get(kind, '#374151')
+    st.markdown(
+        f"<span style='background:{bg}; color:{color}; padding:6px 10px; border-radius:999px; font-size:12px; margin-right:6px; display:inline-block;'>{text}</span>",
+        unsafe_allow_html=True,
+    )
+
+def dim_block(start: bool = True):
+    if start:
+        st.markdown("<div style='opacity:0.5; pointer-events:none;'>", unsafe_allow_html=True)
+    else:
+        st.markdown("</div>", unsafe_allow_html=True)
+
+def get_account_info():
+    return get_json(f"{MT5_URL}/account_info", headers=GATEWAY_HEADERS, timeout=3)
+
+def get_positions() -> List[Dict[str, Any]]:
+    return get_json(f"{MT5_URL}/positions_get", headers=GATEWAY_HEADERS, timeout=3) or []
+
+def get_session_time_remaining():
+    now = dt.datetime.utcnow()
+    end = now.replace(hour=21, minute=0, second=0, microsecond=0)
+    if now > end:
+        end = end + dt.timedelta(days=1)
+    return (end - now)
+
+def pnl_unrealized(positions: list) -> float:
+    return float(sum(float(p.get('profit', 0.0)) for p in positions))
+
+def exposure_percent_stub(positions: list, account: dict) -> float:
+    # ↪ Replace with live risk_enforcer metric when available
+    return min(100.0, max(0.0, 10.0 * len(positions)))
+
+def type_to_text(t: int) -> str:
+    return 'BUY' if int(t) == 0 else 'SELL' if int(t) == 1 else str(t)
+
+def secs_to_hms(seconds: int) -> str:
+    if seconds <= 0:
+        return '—'
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h:d}:{m:02d}:{s:02d}"
+
+# ---------------- UI ----------------
+st.set_page_config(page_title='Pulse – Intraday', layout='wide')
+st.title('Pulse – Intraday Trader View')
+
+metrics_cfg = load_yaml(METRICS_PATH)
+soft_prompt = load_prompt(PROMPT_PATH)
+
+colA, colB = st.columns([2, 1])
+with colA:
+    st.caption('Real-time, high-signal metrics with behavioral overlays.')
+with colB:
+    if soft_prompt:
+        with st.expander('Soft Prompt (session guidance)'):
+            st.write(soft_prompt)
+
+# Data fetch
+account = get_account_info()
+positions = get_positions()
+
+# ---------------- Session Metrics ----------------
+st.subheader('Session')
+sm = metrics_cfg.get('session_metrics', {})
+sess_cols = st.columns(4)
+
+if sm.get('start_of_day_balance', False):
+    with sess_cols[0]:
+        bal = account.get('balance') if account else None
+        if bal is None:
+            dim_block(True); st.metric('Start of Day Balance', '—'); dim_block(False)
+        else:
+            st.metric('Start of Day Balance', f"{bal:,.2f}")
+
+if sm.get('current_equity', False):
+    with sess_cols[1]:
+        eq = account.get('equity') if account else None
+        if eq is None:
+            dim_block(True); st.metric('Current Equity', '—'); dim_block(False)
+        else:
+            st.metric('Current Equity', f"{eq:,.2f}")
+
+if sm.get('daily_risk_allowance_percent', False) or sm.get('current_risk_used_percent', False):
+    with sess_cols[2]:
+        # ↪ Replace with live risk_enforcer metrics
+        risk_allow = 2.0  # %
+        risk_used  = 0.8  # %
+        donut(risk_used, 0, risk_allow, 'Risk Used', '%')
+
+if sm.get('session_time_remaining', False):
+    with sess_cols[3]:
+        rem = get_session_time_remaining()
+        st.metric('Session Time Remaining', str(rem).split('.')[0] if rem else '—')
+
+# ---------------- Trade Metrics ----------------
+st.subheader('Trades')
+tm = metrics_cfg.get('trade_metrics', {})
+tcols = st.columns(4)
+
+if tm.get('unrealized_pnl', False):
+    with tcols[0]:
+        upnl = pnl_unrealized(positions)
+        st.metric('Unrealized PnL', f"{upnl:,.2f}")
+        chip('Live', 'good' if positions else 'neutral')
+
+if tm.get('time_in_trade', False):
+    with tcols[1]:
+        # Show max time-in-trade across open positions (placeholder if times absent)
+        now = int(time.time())
+        durations = []
+        for p in positions:
+            t_open = int(p.get('time', 0))  # MT5 positions usually include 'time'
+            if t_open > 0:
+                durations.append(now - t_open)
+        if durations:
+            st.metric('Time in Trade (max)', secs_to_hms(max(durations)))
+        else:
+            dim_block(True); st.metric('Time in Trade', '—'); dim_block(False)
+
+if tm.get('exposure_percent', False):
+    with tcols[2]:
+        exp = exposure_percent_stub(positions, account)
+        donut(exp, 0, 100, 'Exposure', '%')
+
+if tm.get('max_adverse_excursion', False):
+    with tcols[3]:
+        dim_block(True); st.metric('Max Adverse Excursion', '—'); dim_block(False)
+# ---------------- Behavioral Metrics ----------------
+st.subheader('Behavior')
+bm = metrics_cfg.get('behavioral_metrics', {})
+bcols = st.columns(5)
+
+def placeholder_chip(name: str):
+    with st.container():
+        dim_block(True); chip(f"{name}: pending", 'neutral'); dim_block(False)
+
+if bm.get('composite_posture_score', False):
+    with bcols[0]: placeholder_chip('Posture')
+if bm.get('patience_index', False):
+    with bcols[1]: placeholder_chip('Patience')
+if bm.get('conviction_accuracy', False):
+    with bcols[2]: placeholder_chip('Conviction')
+if bm.get('profit_efficiency', False):
+    with bcols[3]: placeholder_chip('Profit Eff.')
+if bm.get('overtrading_alert', False):
+    with bcols[4]: chip('Overtrading: OK', 'good')  # ↪ Replace with live journal count vs. limits
+
+# ---------------- Future Signals ----------------
+st.subheader('Future Signals')
+fs = metrics_cfg.get('future_signals', {})
+fcols = st.columns(3)
+with fcols[0]:
+    # ↪ Wire to news/calendar microservice; placeholder until live
+    dim_block(True); st.metric('Next News Release', '—'); dim_block(False)
+with fcols[1]:
+    dim_block(True); chip('Context Alerts: —', 'neutral'); dim_block(False)
+with fcols[2]:
+    dim_block(True); chip('Whisperer Rating: —', 'neutral'); dim_block(False)
+
+st.caption('Gray elements indicate metrics not yet live or awaiting data.')
+
+# ---------------- Position Manager ----------------
+st.subheader('Open Positions')
+if not positions:
+    st.info('No open positions.')
+else:
+    st.checkbox('Enable trade actions', key='enable_actions', value=False, help='Guardrail to prevent accidental clicks')
+    for i, p in enumerate(positions):
+        with st.container():
+            cols = st.columns([2, 1, 1, 1, 1, 2])
+            cols[0].markdown(f"**{p.get('symbol','')}**")
+            cols[1].markdown(type_to_text(p.get('type', -1)))
+            cols[2].markdown(f"Vol: {float(p.get('volume',0.0)):.2f}")
+            cols[3].markdown(f"Open: {float(p.get('price_open',0.0)):.5f}")
+            cols[4].markdown(f"P/L: {float(p.get('profit',0.0)):.2f}")
+            with cols[5]:
+                ticket = int(p.get('ticket'))
+                c1, c2 = st.columns(2)
+                if c1.button('Close', key=f"close_{ticket}", use_container_width=True, disabled=not st.session_state.enable_actions):
+                    with st.spinner('Closing...'):
+                        ok, data = post_actions(
+                            {'type': 'position_close', 'payload': {'ticket': ticket}},
+                            idempotency_key=f"close-{ticket}-{uuid.uuid4().hex[:8]}",
+                        )
+                    st.success('Close requested') if ok else st.error(f"Close failed: {data}")
+                if c2.button('Partial 50%', key=f"p50_{ticket}", use_container_width=True, disabled=not st.session_state.enable_actions):
+                    with st.spinner('Partial closing 50%...'):
+                        ok, data = post_actions(
+                            {'type': 'position_close', 'payload': {'ticket': ticket, 'fraction': 0.5}},
+                            idempotency_key=f"p50-{ticket}-{uuid.uuid4().hex[:8]}",
+                        )
+                    st.success('Partial requested') if ok else st.error(f"Partial failed: {data}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,6 +133,14 @@ services:
       - .env
     environment:
       - MT5_API_URL=http://mt5:5001
+      - MT5_URL=http://mt5:5001
+      - DJANGO_API_URL=http://django:8000
+      - DJANGO_API_PREFIX=/api/v1
+      - BRIDGE_TOKEN=${BRIDGE_TOKEN:-}
+      - MT5_URL=http://mt5:5001
+      - DJANGO_API_URL=http://django:8000
+      - DJANGO_API_PREFIX=/api/v1
+      - BRIDGE_TOKEN=${BRIDGE_TOKEN:-}
       - MT5_API_STUB_FALLBACK=1
     networks:
       - traefik-public
@@ -591,6 +599,10 @@ services:
       - PYTHONPATH=/app:/app/components:/app/utils:/app/api_integration
       - PULSE_API_URL=http://django:8000
       - MT5_API_URL=http://mt5:5001
+      - MT5_URL=http://mt5:5001
+      - DJANGO_API_URL=http://django:8000
+      - DJANGO_API_PREFIX=/api/v1
+      - BRIDGE_TOKEN=${BRIDGE_TOKEN:-}
     depends_on:
       mt5:
         condition: service_started

--- a/requirements-dashboard.txt
+++ b/requirements-dashboard.txt
@@ -1,8 +1,9 @@
-streamlit
-plotly
+streamlit>=1.32
+plotly>=5.22.0
 pandas
 numpy
 pytz
 MetaTrader5
 redis
-pyyaml
+pyyaml>=6.0
+requests>=2.31


### PR DESCRIPTION
## Summary
- Add Pulse dashboard page showing MT5 metrics, soft prompt, and safe trade actions
- Provide config files for prompt and metric toggles
- Update dashboard requirements and compose env vars for MT5 and Django APIs

## Testing
- `curl http://mt5:5001/health` *(fails: DNS resolution failure)*
- `curl http://mt5:5001/account_info` *(fails: DNS resolution failure)*
- `curl http://mt5:5001/positions_get` *(fails: DNS resolution failure)*
- `curl -X POST http://django:8000/api/v1/actions/query -H "Content-Type: application/json" -d '{"type":"position_close","payload":{"ticket":123}}'` *(fails: DNS resolution failure)*
- `pytest` *(fails: conlist() got an unexpected keyword argument 'min_items', ModuleNotFoundError, populate() isn't reentrant, and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c01e9823ec832884f1168758de5006