### PR TITLE
Add MT5 trade bridge and FastAPI trade endpoints

### DIFF
--- a/actions/OPENAI_ACTIONS.yaml
+++ b/actions/OPENAI_ACTIONS.yaml
@@ -196,3 +196,45 @@ actions:
           type: number
           description: Optional hedge volume (defaults to full position volume)
       required: [ticket]
+
+  - name: trade_open
+    description: Open a new trading position
+    endpoint: /trade/open
+    method: POST
+    parameters:
+      type: object
+      properties:
+        symbol: { type: string }
+        side: { type: string, enum: [buy, sell] }
+        volume: { type: number }
+        type: { type: string, enum: [market, limit, stop], nullable: true }
+        price: { type: number, nullable: true }
+        sl: { type: number, nullable: true }
+        tp: { type: number, nullable: true }
+        deviation: { type: integer, nullable: true }
+        client_order_id: { type: string, nullable: true }
+      required: [symbol, side, volume]
+
+  - name: trade_close
+    description: Close an existing trading position
+    endpoint: /trade/close
+    method: POST
+    parameters:
+      type: object
+      properties:
+        ticket: { type: integer, description: Trade ticket ID to close }
+        volume: { type: number, nullable: true, description: Optional volume to close }
+        deviation: { type: integer, nullable: true }
+      required: [ticket]
+
+  - name: trade_modify
+    description: Modify stop-loss or take-profit for a position
+    endpoint: /trade/modify
+    method: POST
+    parameters:
+      type: object
+      properties:
+        ticket: { type: integer, description: Trade ticket ID }
+        sl: { type: number, nullable: true }
+        tp: { type: number, nullable: true }
+      required: [ticket]

--- a/api/trade.py
+++ b/api/trade.py
@@ -1,0 +1,65 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from trade_bridge import open_position, close_position, modify_sl_tp
+
+router = APIRouter(prefix="/trade", tags=["trade"])
+
+
+class OpenRequest(BaseModel):
+    symbol: str
+    side: str
+    volume: float
+    type: str = Field("market", pattern="^(market|limit|stop)$")
+    price: float | None = None
+    sl: float | None = None
+    tp: float | None = None
+    deviation: int = 10
+    client_order_id: str | None = None
+
+
+@router.post("/open")
+def open_trade(req: OpenRequest):
+    try:
+        result = open_position(
+            symbol=req.symbol,
+            side=req.side,
+            volume=req.volume,
+            type_=req.type,
+            price=req.price,
+            sl=req.sl,
+            tp=req.tp,
+            deviation=req.deviation,
+        )
+        return {"result": result._asdict()}
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+class CloseRequest(BaseModel):
+    ticket: int
+    volume: float | None = None
+    deviation: int = 10
+
+
+@router.post("/close")
+def close_trade(req: CloseRequest):
+    try:
+        result = close_position(req.ticket, req.volume, req.deviation)
+        return {"result": result._asdict()}
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+class ModifyRequest(BaseModel):
+    ticket: int
+    sl: float | None = None
+    tp: float | None = None
+
+
+@router.post("/modify")
+def modify_trade(req: ModifyRequest):
+    try:
+        result = modify_sl_tp(req.ticket, req.sl, req.tp)
+        return {"result": result._asdict()}
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Dict, Any
 from fastapi import FastAPI, Depends, HTTPException, Body, Query
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field, conlist, confloat
+from api.trade import router as trade_router
 
 try:
     from pulse_kernel import PulseKernel
@@ -75,7 +76,7 @@ class TopSignal(BaseModel):
 
 
 class TopSignalsResponse(BaseModel):
-    items: conlist(TopSignal, min_items=0, max_items=25)
+    items: conlist(TopSignal, min_length=0, max_length=25)
 
 
 class PulseRuntime:
@@ -111,6 +112,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(trade_router)
 
 
 @app.get("/pulse/health")

--- a/openapi.actions.yaml
+++ b/openapi.actions.yaml
@@ -389,6 +389,68 @@ paths:
         '404': { description: Not Found }
         '500': { description: Server Error }
 
+  /trade/open:
+    post:
+      summary: Open a new trading position
+      operationId: postTradeOpen
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PositionOpenPayload'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PositionActionResponse'
+        '400': { description: Bad Request }
+        '500': { description: Server Error }
+
+  /trade/close:
+    post:
+      summary: Close an existing trading position
+      operationId: postTradeClose
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PositionClosePayload'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PositionActionResponse'
+        '400': { description: Bad Request }
+        '404': { description: Not Found }
+        '500': { description: Server Error }
+
+  /trade/modify:
+    post:
+      summary: Modify stop-loss or take-profit for a position
+      operationId: postTradeModify
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PositionModifyPayload'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PositionActionResponse'
+        '400': { description: Bad Request }
+        '404': { description: Not Found }
+        '500': { description: Server Error }
+
 components:
   schemas:
     ActionQuery:

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,3 +64,4 @@ asyncpg==0.29.0
 fakeredis==2.23.2
 confluent-kafka==2.3.0
 tenacity==8.2.3
+MetaTrader5==5.0.45

--- a/trade_bridge.py
+++ b/trade_bridge.py
@@ -1,0 +1,126 @@
+try:
+    import MetaTrader5 as mt5  # type: ignore
+except Exception as exc:  # pragma: no cover - runtime import guard
+    mt5 = None
+    _import_error = exc
+
+
+def _ensure_connected():
+    if mt5 is None:
+        raise RuntimeError(f"MetaTrader5 module not available: {_import_error}")
+    if not mt5.initialize():
+        raise RuntimeError(f"MT5 init failed: {mt5.last_error()}")
+
+
+def _symbol_info_tick(symbol):
+    info = mt5.symbol_info(symbol)
+    if info is None or not info.visible:
+        if not mt5.symbol_select(symbol, True):
+            raise RuntimeError(f"Cannot select symbol {symbol}")
+    tick = mt5.symbol_info_tick(symbol)
+    if tick is None:
+        raise RuntimeError(f"No tick for {symbol}")
+    return info, tick
+
+
+def _assert_ok(result):
+    if result is None:
+        raise RuntimeError(f"order_send returned None: {mt5.last_error()}")
+    if result.retcode != mt5.TRADE_RETCODE_DONE:
+        raise RuntimeError(f"Broker rejected ({result.retcode}): {result.comment}")
+    return result
+
+
+def open_position(
+    symbol,
+    side,
+    volume,
+    type_="market",
+    price=None,
+    sl=None,
+    tp=None,
+    deviation=10,
+    magic=777,
+):
+    _ensure_connected()
+    info, tick = _symbol_info_tick(symbol)
+
+    if type_ == "market":
+        order_type = mt5.ORDER_TYPE_BUY if side == "buy" else mt5.ORDER_TYPE_SELL
+        price_used = tick.ask if side == "buy" else tick.bid
+    elif type_ == "limit":
+        order_type = mt5.ORDER_TYPE_BUY_LIMIT if side == "buy" else mt5.ORDER_TYPE_SELL_LIMIT
+        price_used = float(price)
+    elif type_ == "stop":
+        order_type = mt5.ORDER_TYPE_BUY_STOP if side == "buy" else mt5.ORDER_TYPE_SELL_STOP
+        price_used = float(price)
+    else:
+        raise ValueError("type_ must be market|limit|stop")
+
+    request = {
+        "action": mt5.TRADE_ACTION_DEAL if type_ == "market" else mt5.TRADE_ACTION_PENDING,
+        "symbol": symbol,
+        "volume": float(volume),
+        "type": order_type,
+        "price": price_used,
+        "sl": float(sl) if sl else 0.0,
+        "tp": float(tp) if tp else 0.0,
+        "deviation": int(deviation),
+        "magic": int(magic),
+        "comment": "open_v1",
+        "type_time": mt5.ORDER_TIME_GTC,
+        "type_filling": mt5.ORDER_FILLING_IOC if type_ == "market" else mt5.ORDER_FILLING_RETURN,
+    }
+
+    result = mt5.order_send(request)
+    return _assert_ok(result)
+
+
+def close_position(ticket, volume=None, deviation=10, magic=777):
+    _ensure_connected()
+    pos = next((p for p in mt5.positions_get() if p.ticket == ticket), None)
+    if pos is None:
+        raise ValueError(f"Position {ticket} not found")
+
+    vol_to_close = float(volume) if volume else float(pos.volume)
+    order_type = mt5.ORDER_TYPE_SELL if pos.type == mt5.POSITION_TYPE_BUY else mt5.ORDER_TYPE_BUY
+    tick = mt5.symbol_info_tick(pos.symbol)
+    price_used = tick.bid if order_type == mt5.ORDER_TYPE_SELL else tick.ask
+
+    request = {
+        "action": mt5.TRADE_ACTION_DEAL,
+        "position": ticket,
+        "symbol": pos.symbol,
+        "volume": vol_to_close,
+        "type": order_type,
+        "price": price_used,
+        "deviation": int(deviation),
+        "magic": int(magic),
+        "comment": "close_v1",
+        "type_time": mt5.ORDER_TIME_GTC,
+        "type_filling": mt5.ORDER_FILLING_IOC,
+    }
+
+    result = mt5.order_send(request)
+    return _assert_ok(result)
+
+
+def modify_sl_tp(ticket, sl=None, tp=None):
+    _ensure_connected()
+    pos = next((p for p in mt5.positions_get() if p.ticket == ticket), None)
+    if pos is None:
+        raise ValueError(f"Position {ticket} not found")
+
+    new_sl = float(sl) if sl else pos.sl
+    new_tp = float(tp) if tp else pos.tp
+
+    request = {
+        "action": mt5.TRADE_ACTION_SLTP,
+        "position": ticket,
+        "symbol": pos.symbol,
+        "sl": new_sl if new_sl else 0.0,
+        "tp": new_tp if new_tp else 0.0,
+        "comment": "modify_v1",
+    }
+    result = mt5.order_send(request)
+    return _assert_ok(result)


### PR DESCRIPTION
## Summary
- add MetaTrader5 trade bridge with open/close/modify helpers
- expose new /trade/open, /trade/close, and /trade/modify endpoints via FastAPI router
- wire trade routes into main FastAPI app and add MetaTrader5 dependency
- document trade endpoints for OpenAI Actions and expose through plugin manifest
- adjust TopSignalsResponse for Pydantic v2 compatibility

## Testing
- `pytest tests/test_api_smoke.py::test_health tests/test_api_smoke.py::test_score_minimal -q`


------
https://chatgpt.com/codex/tasks/task_b_68c047b2df6c83289f5a9fffe39193ea