### PR TITLE
Implement account info view to avoid import error

### DIFF
--- a/backend/django/app/nexus/views.py
+++ b/backend/django/app/nexus/views.py
@@ -2192,7 +2192,22 @@ class AccountInfoView(views.APIView):
     permission_classes = [AllowAny]
 
     def get(self, request):
-
+        for base in _mt5_bases():
+            try:
+                r = requests.get(f"{base}/account_info", timeout=2.5)
+                if not r.ok:
+                    continue
+                data = r.json() or {}
+                if isinstance(data, list) and data:
+                    data = data[0]
+                if not isinstance(data, dict):
+                    continue
+                out = {str(k).lower(): v for k, v in data.items()}
+                return Response(out)
+            except Exception:
+                logger.exception("account_info request failed")
+                continue
+        return Response({"error": "mt5 bridge unreachable"}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
 class JournalAppendView(views.APIView):
     """Append a journal entry; optionally linked to a trade by id.
 


### PR DESCRIPTION
## Summary
- Implement AccountInfoView.get to query MT5 bridge for account information and normalize response
- Provide graceful error if MT5 bridge is unreachable

## Testing
- ⚠️ `pytest -q` (module import errors: ModuleNotFoundError: No module named 'app.nexus')
- ✅ `pytest tests/test_mt5_proxy_views.py::test_account_info_uses_api_url -q`

------
https://chatgpt.com/codex/tasks/task_b_68c053376cec8328a8b0938e593bf451