### PR TITLE
docs: describe Pulse intraday dashboard

### DIFF
--- a/dashboard/pages/README.md
+++ b/dashboard/pages/README.md
@@ -4,6 +4,7 @@ Dashboard Pages (Active)
 Highlights
 ----------
 
+- Page 01 — Pulse – Intraday Trader View: real-time session/trade metrics with behavioral overlays; position manager with close/partial actions
 - Page 12 — PULSE Flow: lights + Structure/Liquidity/Risk details; symbol picker with favorite setting
 - Page 07 — ZANFLOW v12: Live/DB/Parquet fallbacks; symbol picker uses favorite
 - Pages 16/17/19/20 — Risk dashboards; Settings sidebar includes favorite symbol; consistent styling


### PR DESCRIPTION
## Summary
- document Pulse Intraday Trader View page and its real-time metrics and position manager

## Testing
- `pytest` *(fails: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c09e641da88328a6c3bbde2f26eed2