### PR TITLE
docs: clarify dashboard metric toggles

### DIFF
--- a/dashboard/config/dashboard_metrics_summary.yaml
+++ b/dashboard/config/dashboard_metrics_summary.yaml
@@ -1,3 +1,4 @@
+## Session-level statistics; toggle booleans to show or hide each metric on the dashboard.
 session_metrics:
   start_of_day_balance: true
   current_equity: true
@@ -5,12 +6,14 @@ session_metrics:
   current_risk_used_percent: true
   session_time_remaining: true
 
+## Metrics for individual trades; set to true to display values in the UI.
 trade_metrics:
   unrealized_pnl: true
   time_in_trade: true
   exposure_percent: true
   max_adverse_excursion: true
 
+## Behavioral analytics summarizing trader performance; booleans control visibility.
 behavioral_metrics:
   composite_posture_score: true
   patience_index: true
@@ -18,6 +21,7 @@ behavioral_metrics:
   profit_efficiency: true
   overtrading_alert: true
 
+## Upcoming signals and alerts; switch booleans to enable corresponding UI elements.
 future_signals:
   next_news_release: true
   context_alerts: true


### PR DESCRIPTION
## Summary
- document dashboard metric sections and note how booleans hide or show UI elements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c0a249459c8328ba0f789a9fc5ef9d