### PR TITLE
chore: remove mt5-api dependency from django

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,8 +222,6 @@ services:
         condition: service_started
       redis:
         condition: service_healthy
-      mt5-api:
-        condition: service_healthy
     networks:
       - default
       - traefik-public


### PR DESCRIPTION
## Summary
- decouple django from mt5-api in docker-compose

## Testing
- `python - <<'PY'
import yaml
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c0a9a917f88328883d8cd770859401