### PR TITLE
Add interactive Whisperer demo page

### DIFF
--- a/pages/InteractiveDemo.py
+++ b/pages/InteractiveDemo.py
@@ -1,0 +1,52 @@
+import streamlit as st
+from dashboard.utils.streamlit_api import safe_api_call
+from .utils import donut_chart
+
+
+def render(mock_data):
+    st.title("Interactive Whisperer Demo")
+
+    col1, col2 = st.columns(2)
+    with col1:
+        confluence = st.slider("Confluence", 0, 100, 50)
+        st.plotly_chart(donut_chart("Confluence", confluence), use_container_width=True)
+    with col2:
+        risk_used = st.slider("Risk Used (%)", 0, 100, 20)
+        st.plotly_chart(donut_chart("Risk", risk_used), use_container_width=True)
+
+    st.subheader("Ask Whisperer")
+    question = st.text_area("Question or journal note")
+    symbol = st.text_input("Symbol", "XAUUSD")
+    if st.button("Send to Whisperer") and question.strip():
+        with st.spinner("Contacting Whisperer..."):
+            resp = safe_api_call(
+                "POST",
+                "api/v1/actions/query",
+                {
+                    "type": "whisper_suggest",
+                    "payload": {
+                        "user_id": "demo",
+                        "symbol": symbol,
+                        "question": question,
+                        "metrics": {"confluence": confluence, "risk": risk_used},
+                    },
+                },
+                timeout=5.0,
+            )
+        if resp.get("error"):
+            st.error(f"API error: {resp['error']}")
+        else:
+            if resp.get("message"):
+                st.success(resp["message"])
+            for h in resp.get("heuristics") or []:
+                st.markdown(f"**{h.get('category', '')}:** {h.get('message', '')}")
+                reasons = h.get("reasons") or []
+                if reasons:
+                    with st.expander("Reasons"):
+                        for r in reasons:
+                            st.write(f"- {r.get('key')}: {r.get('value')}")
+                actions = h.get("actions") or []
+                if actions:
+                    st.write("Actions:")
+                    for a in actions:
+                        st.write(f"- {a.get('label')}")

--- a/wiki_dashboard.py
+++ b/wiki_dashboard.py
@@ -12,7 +12,7 @@ import streamlit as st
 
 from datetime import datetime
 
-from pages import Edges, Home, RiskOpsRunbook, Strategies, HowTo
+from pages import Edges, Home, RiskOpsRunbook, Strategies, HowTo, InteractiveDemo
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +53,7 @@ mock_data = {
         "edges": ["Am I overtrading?"],
         "risk": ["Check my risk budget"],
         "howto": ["How do I use the Confluence Scorer?", "Best way to ask Whisperer questions?"],
+        "interactive": ["Can you walk me through a demo?"],
     },
     "journal_entries": [
         {
@@ -99,6 +100,7 @@ PAGE_KEYS = {
     "Edges": "edges",
     "Risk, Ops & Runbook": "risk",
     "HowTo": "howto",
+    "Interactive Demo": "interactive",
 }
 
 page_modules = {
@@ -107,6 +109,7 @@ page_modules = {
     "Edges": Edges,
     "Risk, Ops & Runbook": RiskOpsRunbook,
     "HowTo": HowTo,
+    "Interactive Demo": InteractiveDemo,
 }
 
 missing_keys = set(page_modules) - set(PAGE_KEYS)


### PR DESCRIPTION
## Summary
- Add InteractiveDemo Streamlit page with metric sliders, donut charts, and Whisperer API queries
- Register Interactive Demo in wiki dashboard navigation and prompts

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c0be0eea448328aa672f509559021c