### PR TITLE
Add WordPress service with Traefik routing

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -65,6 +65,15 @@ VNC_DOMAIN=vnc.localhost
 API_DOMAIN=api.localhost
 DASHBOARD_DOMAIN=dash.localhost
 GRAFANA_DOMAIN=grafana.localhost
+INFO_DOMAIN=info.localhost
+
+# -----------------------------------------------------------------------------
+# WORDPRESS SETTINGS
+# -----------------------------------------------------------------------------
+WORDPRESS_DB_HOST=mysql
+WORDPRESS_DB_USER=wp_user
+WORDPRESS_DB_PASSWORD=your_secure_wordpress_db_password_here
+WORDPRESS_DB_NAME=wordpress
 
 # -----------------------------------------------------------------------------
 # MT5 SETTINGS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -689,6 +689,36 @@ services:
     networks:
       - default
 
+  wordpress:
+    image: wordpress:latest
+    container_name: wordpress
+    restart: unless-stopped
+    volumes:
+      - ./wordpress:/var/www/html/wp-content
+    env_file:
+      - .env
+    environment:
+      WORDPRESS_DB_HOST: ${WORDPRESS_DB_HOST:-}
+      WORDPRESS_DB_USER: ${WORDPRESS_DB_USER:-}
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD:-}
+      WORDPRESS_DB_NAME: ${WORDPRESS_DB_NAME:-}
+    networks:
+      - default
+      - traefik-public
+    labels:
+      <<: *default-labels
+      traefik.enable: true
+      traefik.docker.network: traefik-public
+      traefik.http.routers.wordpress-http.rule: Host(`${INFO_DOMAIN}`)
+      traefik.http.routers.wordpress-http.entrypoints: http
+      traefik.http.routers.wordpress-http.middlewares: https-redirect
+      traefik.http.routers.wordpress-https.rule: Host(`${INFO_DOMAIN}`)
+      traefik.http.routers.wordpress-https.entrypoints: https
+      traefik.http.routers.wordpress-https.tls: true
+      traefik.http.routers.wordpress-https.tls.certresolver: le
+      traefik.http.routers.wordpress-https.service: wordpress-service
+      traefik.http.services.wordpress-service.loadbalancer.server.port: 80
+
   market-fetcher:
     image: curlimages/curl:8.8.0
     container_name: market-fetcher


### PR DESCRIPTION
## Summary
- Add WordPress service to `docker-compose.yml` with Traefik labels for `INFO_DOMAIN`
- Provide `wordpress/` directory for themes and plugins and mount it inside the container
- Extend `.env.template` with WordPress domain and database configuration placeholders

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c0bfa6f8188328b9ca4975c1bf56ee