### PR TITLE
Refactor wiki dashboard into modular pages

### DIFF
--- a/wiki_dashboard.py
+++ b/wiki_dashboard.py
@@ -9,6 +9,7 @@ container which is exposed on port 8503 (see `WIKI_DASHBOARD_PORT`).
 from __future__ import annotations
 
 import graphviz
+import importlib
 import plotly.graph_objects as go
 import streamlit as st
 
@@ -187,134 +188,25 @@ st.markdown(
 # Navigation
 # ---------------------------------------------------------------------------
 
-pages = ["Home", "Strategies", "Edges", "Risk, Ops & Runbook"]
-page = st.sidebar.selectbox("Pages", pages)
+PAGE_MODULES = {
+    "Home": ("wiki_pages.home", "home"),
+    "Strategies": ("wiki_pages.strategies", "strategies"),
+    "Edges": ("wiki_pages.edges", "edges"),
+    "Risk, Ops & Runbook": ("wiki_pages.risk_ops_runbook", "risk"),
+}
+
+page = st.sidebar.selectbox("Pages", list(PAGE_MODULES.keys()))
 
 st.sidebar.markdown("<div class='ask-whisperer'>", unsafe_allow_html=True)
 st.sidebar.subheader("Ask Whisperer")
-for prompt in mock_data["whisperer_prompts"].get(page.lower(), []):
+module_path, prompt_key = PAGE_MODULES[page]
+for prompt in mock_data["whisperer_prompts"].get(prompt_key, []):
     st.sidebar.write(f"- {prompt}")
 whisper_input = st.sidebar.text_input("Your question:")
 if whisper_input:
     st.sidebar.write("Whisperer: Processing... (structured response: Signal • Risk • Action • Journal note)")
 st.sidebar.markdown("</div>", unsafe_allow_html=True)
 
-# ---------------------------------------------------------------------------
-# Pages
-# ---------------------------------------------------------------------------
-
-if page == "Home":
-    st.title("What Pulse Is (and Why It Matters)")
-    st.image("https://placeholder.com/800x300?text=O3+Hero+Image", use_column_width=True)
-    st.subheader("System Architecture")
-    st.graphviz_chart(render_diagram())
-    cols = st.columns(3)
-    with cols[0]:
-        st.markdown(
-            "<div class='status-tile'>What it does: Filters noise into high-conviction trades with AI nudges.</div>",
-            unsafe_allow_html=True,
-        )
-    with cols[1]:
-        st.markdown(
-            "<div class='status-tile'>What's live: Broker feed, Whisperer, Journaling, Behavioral gates.</div>",
-            unsafe_allow_html=True,
-        )
-    with cols[2]:
-        st.markdown(
-            "<div class='status-tile'>What's next: Full Kafka journaling, expanded strategies.</div>",
-            unsafe_allow_html=True,
-        )
-    st.subheader("Live Status")
-    st.write(
-        f"Heartbeat: {mock_data['system_status']['heartbeat']} | Lag: {mock_data['system_status']['lag_ms']}ms"
-    )
-    with st.expander("What to ask Whisperer"):
-        st.write("- Is my entry justified at current confluence?")
-        st.write("- Explain this score drop.")
-
-elif page == "Strategies":
-    st.title("Strategies (Consolidated Cards)")
-    with st.expander("How to read a Strategy Card"):
-        st.write(
-            "Setup: Market conditions. Signals: Entry triggers. Confluence: Score bands. Bias: Direction. Risk gates: Guards. Journal hook: What to log."
-        )
-        st.write("Failure modes: Low confluence ignores; misread signals lead to traps.")
-    for strat in mock_data["strategies"]:
-        with st.expander(strat["name"]):
-            st.write(f"**Setup**: {strat['setup']}")
-            st.write(f"**Signals**: {strat['signals']}")
-            st.write(f"**Confluence**: {strat['confluence']}")
-            st.plotly_chart(donut_chart("Example Score", mock_data["confluence_score"]), use_container_width=True)
-            st.write(f"**Bias**: {strat['bias']}")
-            st.write(f"**Risk Gates**: {strat['risk_gates']}")
-            st.write(f"**Journal Hook**: {strat['journal_hook']}")
-    with st.expander("What to ask Whisperer"):
-        st.write("- Pre-trade: Validate this setup?")
-        st.write("- Post-trade: Journal with note on bias.")
-
-elif page == "Edges":
-    st.title("Edges: Behavioral + Technical")
-    st.subheader("Behavioral Edge")
-    cols = st.columns(4)
-    metrics = mock_data["behavioral_metrics"]
-    with cols[0]:
-        st.plotly_chart(
-            donut_chart("Discipline", metrics["discipline"], subtitle="Rule adherence")
-        )
-    with cols[1]:
-        st.plotly_chart(
-            donut_chart("Patience", min(100, metrics["patience"] / 3), subtitle="Time between trades")
-        )
-    with cols[2]:
-        st.plotly_chart(
-            donut_chart("Conviction", metrics["conviction"], subtitle="Confidence wins")
-        )
-    with cols[3]:
-        st.plotly_chart(
-            donut_chart("Efficiency", metrics["efficiency"], subtitle="Profit captured")
-        )
-    st.write(
-        "Enforced by Risk Enforcer: Cooldowns after losses, max 3-5 trades/day, anti-revenge detection."
-    )
-    with st.expander("What Behavioral Means"):
-        st.write(
-            "Discipline prevents overtrading; Patience curbs FOMO; Conviction checks intuition; Efficiency maximizes R:R."
-        )
-    st.subheader("Technical Edge")
-    st.write("MIDAS: Data hygiene for VWAP channels. SMC/Wyckoff: Structure over TA. Microstructure: Order flow timing via NCOS.")
-    fig = go.Figure(
-        go.Pie(labels=["SMC", "Wyckoff", "TA", "Micro"], values=[40, 30, 15, 15], hole=0.3)
-    )
-    st.plotly_chart(fig, use_container_width=True)
-    st.write("Bands: Green >70 (act), Amber 50-70 (warn), Red <50 (block).")
-    with st.expander("What to ask Whisperer"):
-        st.write("- Am I violating cooldown?")
-        st.write("- Adjust confluence weights?")
-
-else:
-    st.title("Risk, Ops & Runbook")
-    st.subheader("Risk Mapping")
-    st.write("Confluence >80: Allow full size. 50-80: Warn, half size. <50: Block.")
-    st.write("Examples: Allowed (high conv), Warn (medium, cooldown), Blocked (low disc).")
-    with st.expander("Allowed / Warn / Blocked Examples"):
-        st.write("- Allowed: Green gates, position_open via Actions Bus.")
-        st.write("- Warn: Amber patience, suggest hedge.")
-        st.write("- Blocked: Red efficiency, reject modify.")
-    st.subheader("Journal Loop")
-    st.write("Records: ENTRY/CLOSE/PARTIAL/HEDGE/MODIFY with meta (from JOURNALING.md).")
-    for entry in mock_data["journal_entries"]:
-        st.write(
-            f"{entry['ts']} - {entry['kind']}: {entry['text']} (Confluence: {entry['meta'].get('confluence', 'N/A')})"
-        )
-    st.write("Weekly reviews: Detect drift via behavior_events.")
-    st.subheader("Operations")
-    st.write(
-        "Run: streamlit run wiki_dashboard.py --server.port="
-        "{st.secrets.get('WIKI_DASHBOARD_PORT', 8503)}"
-    )
-    st.write("Route: Traefik host WIKI_DASHBOARD; verify Django health /api/pulse/health.")
-    with st.expander("Incident Checklist"):
-        st.write("- Capture: Journal append, screenshot.")
-        st.write("- Notify: Dev team via alert.")
-        st.write("- Verify: Check Kafka/Redis logs.")
+module = importlib.import_module(module_path)
+module.render(mock_data)
 

--- a/wiki_pages/edges.py
+++ b/wiki_pages/edges.py
@@ -1,0 +1,44 @@
+import streamlit as st
+import plotly.graph_objects as go
+from wiki_dashboard import donut_chart
+
+
+def render(mock_data):
+    """Render the Edges page."""
+    st.title("Edges: Behavioral + Technical")
+    st.subheader("Behavioral Edge")
+    cols = st.columns(4)
+    metrics = mock_data["behavioral_metrics"]
+    with cols[0]:
+        st.plotly_chart(
+            donut_chart("Discipline", metrics["discipline"], subtitle="Rule adherence")
+        )
+    with cols[1]:
+        st.plotly_chart(
+            donut_chart("Patience", min(100, metrics["patience"] / 3), subtitle="Time between trades")
+        )
+    with cols[2]:
+        st.plotly_chart(
+            donut_chart("Conviction", metrics["conviction"], subtitle="Confidence wins")
+        )
+    with cols[3]:
+        st.plotly_chart(
+            donut_chart("Efficiency", metrics["efficiency"], subtitle="Profit captured")
+        )
+    st.write(
+        "Enforced by Risk Enforcer: Cooldowns after losses, max 3-5 trades/day, anti-revenge detection."
+    )
+    with st.expander("What Behavioral Means"):
+        st.write(
+            "Discipline prevents overtrading; Patience curbs FOMO; Conviction checks intuition; Efficiency maximizes R:R."
+        )
+    st.subheader("Technical Edge")
+    st.write("MIDAS: Data hygiene for VWAP channels. SMC/Wyckoff: Structure over TA. Microstructure: Order flow timing via NCOS.")
+    fig = go.Figure(
+        go.Pie(labels=["SMC", "Wyckoff", "TA", "Micro"], values=[40, 30, 15, 15], hole=0.3)
+    )
+    st.plotly_chart(fig, use_container_width=True)
+    st.write("Bands: Green >70 (act), Amber 50-70 (warn), Red <50 (block).")
+    with st.expander("What to ask Whisperer"):
+        st.write("- Am I violating cooldown?")
+        st.write("- Adjust confluence weights?")

--- a/wiki_pages/home.py
+++ b/wiki_pages/home.py
@@ -1,0 +1,33 @@
+import streamlit as st
+from wiki_dashboard import render_diagram
+
+
+def render(mock_data):
+    """Render the Home page."""
+    st.title("What Pulse Is (and Why It Matters)")
+    st.image("https://placeholder.com/800x300?text=O3+Hero+Image", use_column_width=True)
+    st.subheader("System Architecture")
+    st.graphviz_chart(render_diagram())
+    cols = st.columns(3)
+    with cols[0]:
+        st.markdown(
+            "<div class='status-tile'>What it does: Filters noise into high-conviction trades with AI nudges.</div>",
+            unsafe_allow_html=True,
+        )
+    with cols[1]:
+        st.markdown(
+            "<div class='status-tile'>What's live: Broker feed, Whisperer, Journaling, Behavioral gates.</div>",
+            unsafe_allow_html=True,
+        )
+    with cols[2]:
+        st.markdown(
+            "<div class='status-tile'>What's next: Full Kafka journaling, expanded strategies.</div>",
+            unsafe_allow_html=True,
+        )
+    st.subheader("Live Status")
+    st.write(
+        f"Heartbeat: {mock_data['system_status']['heartbeat']} | Lag: {mock_data['system_status']['lag_ms']}ms"
+    )
+    with st.expander("What to ask Whisperer"):
+        st.write("- Is my entry justified at current confluence?")
+        st.write("- Explain this score drop.")

--- a/wiki_pages/risk_ops_runbook.py
+++ b/wiki_pages/risk_ops_runbook.py
@@ -1,0 +1,30 @@
+import streamlit as st
+
+
+def render(mock_data):
+    """Render the Risk, Ops & Runbook page."""
+    st.title("Risk, Ops & Runbook")
+    st.subheader("Risk Mapping")
+    st.write("Confluence >80: Allow full size. 50-80: Warn, half size. <50: Block.")
+    st.write("Examples: Allowed (high conv), Warn (medium, cooldown), Blocked (low disc).")
+    with st.expander("Allowed / Warn / Blocked Examples"):
+        st.write("- Allowed: Green gates, position_open via Actions Bus.")
+        st.write("- Warn: Amber patience, suggest hedge.")
+        st.write("- Blocked: Red efficiency, reject modify.")
+    st.subheader("Journal Loop")
+    st.write("Records: ENTRY/CLOSE/PARTIAL/HEDGE/MODIFY with meta (from JOURNALING.md).")
+    for entry in mock_data["journal_entries"]:
+        st.write(
+            f"{entry['ts']} - {entry['kind']}: {entry['text']} (Confluence: {entry['meta'].get('confluence', 'N/A')})"
+        )
+    st.write("Weekly reviews: Detect drift via behavior_events.")
+    st.subheader("Operations")
+    st.write(
+        "Run: streamlit run wiki_dashboard.py --server.port="
+        "{st.secrets.get('WIKI_DASHBOARD_PORT', 8503)}"
+    )
+    st.write("Route: Traefik host WIKI_DASHBOARD; verify Django health /api/pulse/health.")
+    with st.expander("Incident Checklist"):
+        st.write("- Capture: Journal append, screenshot.")
+        st.write("- Notify: Dev team via alert.")
+        st.write("- Verify: Check Kafka/Redis logs.")

--- a/wiki_pages/strategies.py
+++ b/wiki_pages/strategies.py
@@ -1,0 +1,26 @@
+import streamlit as st
+from wiki_dashboard import donut_chart
+
+
+def render(mock_data):
+    """Render the Strategies page."""
+    st.title("Strategies (Consolidated Cards)")
+    with st.expander("How to read a Strategy Card"):
+        st.write(
+            "Setup: Market conditions. Signals: Entry triggers. Confluence: Score bands. Bias: Direction. Risk gates: Guards. Journal hook: What to log."
+        )
+        st.write("Failure modes: Low confluence ignores; misread signals lead to traps.")
+    for strat in mock_data["strategies"]:
+        with st.expander(strat["name"]):
+            st.write(f"**Setup**: {strat['setup']}")
+            st.write(f"**Signals**: {strat['signals']}")
+            st.write(f"**Confluence**: {strat['confluence']}")
+            st.plotly_chart(
+                donut_chart("Example Score", mock_data["confluence_score"]), use_container_width=True
+            )
+            st.write(f"**Bias**: {strat['bias']}")
+            st.write(f"**Risk Gates**: {strat['risk_gates']}")
+            st.write(f"**Journal Hook**: {strat['journal_hook']}")
+    with st.expander("What to ask Whisperer"):
+        st.write("- Pre-trade: Validate this setup?")
+        st.write("- Post-trade: Journal with note on bias.")


### PR DESCRIPTION
## Summary
- Restructure `wiki_dashboard.py` to load page modules dynamically via a mapping and preserve shared styling and sidebar prompts
- Isolate page content into new `wiki_pages` modules with dedicated `render` functions

## Testing
- `python -m py_compile wiki_dashboard.py wiki_pages/home.py wiki_pages/strategies.py wiki_pages/edges.py wiki_pages/risk_ops_runbook.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c0ad8d326c8328ad3fc06c816e7f59