### PR TITLE
feat: add whisperer MCP agent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -719,6 +719,19 @@ services:
       traefik.http.routers.wordpress-https.service: wordpress-service
       traefik.http.services.wordpress-service.loadbalancer.server.port: 80
 
+  whisperer-mcp:
+    image: python:3.11-slim
+    container_name: whisperer-mcp
+    working_dir: /app
+    command: sh -lc "pip install --no-cache-dir fastapi uvicorn[standard] httpx && uvicorn whisperer_agent:app --host 0.0.0.0 --port 9000"
+    volumes:
+      - .:/app
+    ports:
+      - 9000:9000
+    restart: unless-stopped
+    networks:
+      - default
+
   market-fetcher:
     image: curlimages/curl:8.8.0
     container_name: market-fetcher

--- a/whisperer_agent.py
+++ b/whisperer_agent.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+from dataclasses import asdict
+from whisper_engine import WhisperEngine, State
+
+app = FastAPI(title="Whisperer MCP")
+
+# Initialize the whisper engine with default configuration
+engine = WhisperEngine(cfg={})
+
+@app.post("/mcp")
+async def mcp(state: State):
+    """Evaluate a trading state and return any generated whispers."""
+    whispers = engine.evaluate(state)
+    return [asdict(w) for w in whispers]


### PR DESCRIPTION
## Summary
- add FastAPI-based whisperer MCP endpoint
- launch whisperer-mcp service via docker-compose

## Testing
- `pytest` *(fails: RuntimeError: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c0c6895fd083288a788aa795b74aee