### PR TITLE
feat: trust actions bus and expose MCP1 auth

### DIFF
--- a/docs/ACTIONS_API_OVERVIEW.md
+++ b/docs/ACTIONS_API_OVERVIEW.md
@@ -135,6 +135,11 @@ Example flow:
 The backend validates this against `JournalAppendPayload`, logs it, streams it
 to Kafka, and returns `{ "success": true }`.
 
+MCP1 Integration
+-----------------
+The Actions schema also exposes `/api/v1/mcp1/authenticate` for realtime OpenAI services.
+Send `{ "token": "<jwt>" }` and receive `{ "status": "authenticated" }` when valid.
+
 See also:
 - [Actions Bus](ACTIONS_BUS.md)
 - [Verbs Catalog](VERBS_CATALOG.md)

--- a/docs/ACTIONS_BUS.md
+++ b/docs/ACTIONS_BUS.md
@@ -79,8 +79,13 @@ Trusted Connector Setup
     permissions:
       - domain: django2.zanalytics.app
         always_allow: true
+    scopes:
+      - read
+      - write
+      - execute
   ```
 - Operational guardrails when auto‑allow is enabled:
   - Require `X-Idempotency-Key` for mutating calls.
   - Journal all trade actions (`/api/v1/journal/append`).
   - Optionally scope permissions to specific verbs or restrict in your client runtime.
+  - For realtime features, authenticate via `/api/v1/mcp1/authenticate`.

--- a/docs/VERBS_CATALOG.md
+++ b/docs/VERBS_CATALOG.md
@@ -14,6 +14,7 @@ Index
 - Account/State: session_boot, state_snapshot, account_info, account_positions, account_risk, equity_today
 - Market/Scan: market_mini, market_snapshot, market_symbols, market_calendar_next, market_regime, liquidity_map, pulse_status, opportunity_priority_items
 - Journal/Behavior: journal_recent, journal_append, behavior_events, whisper_suggest
+- Auth: mcp1_authenticate
 
 Positions
 
@@ -166,6 +167,14 @@ whisper_suggest
   - user_id: string, optional
   - symbol: string, optional (default XAUUSD)
 - Response: { message: string|null, heuristics: [...], meta: { user_id, symbol } }
+
+Auth / MCP1
+
+mcp1_authenticate
+- Payload
+  - token: string
+- Response
+  - { status: string }
 
 Notes on idempotency
 - Send `X-Idempotency-Key` header on mutating actions (open/close/modify/hedge, journal_append) to dedupe retries.

--- a/docs/WHISPERER.md
+++ b/docs/WHISPERER.md
@@ -11,6 +11,9 @@ Surfaces
 - SSE feed (optional): `GET /api/v1/feeds/stream?topics=whispers`
   - Streamed events with `event: whisper` and `data: {...}`
 
+Trusted connector
+- When `openapi.actions.yaml` includes the `x-openai.trusted` block with scopes, Whisperer calls execute without user confirmation dialogs.
+
 Server implementation
 - Router: `backend/django/app/nexus/views.py` → `ActionsQueryView.post()` case `whisper_suggest`
 - Engine: `whisper_engine.py` defines `WhisperEngine` and `State` input

--- a/openapi.actions.yaml
+++ b/openapi.actions.yaml
@@ -12,6 +12,10 @@ x-openai:
   permissions:
     - domain: django2.zanalytics.app
       always_allow: true
+  scopes:
+    - read
+    - write
+    - execute
 paths:
   /api/v1/actions/read:
     get:
@@ -450,6 +454,30 @@ paths:
         '400': { description: Bad Request }
         '404': { description: Not Found }
         '500': { description: Server Error }
+
+  /api/v1/mcp1/authenticate:
+    post:
+      summary: Authenticate session via MCP1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+      responses:
+        '200':
+          description: Session valid
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: authenticated
 
 components:
   schemas:


### PR DESCRIPTION
## Summary
- mark Actions Bus OpenAPI as trusted with read/write/execute scopes
- expose `/api/v1/mcp1/authenticate` for MCP1 session validation
- document trusted connector usage and new verb in Actions docs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c0d0b68b64832890936f75c277e664