### PR TITLE
chore: remove unused streamlit uac service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -629,15 +629,6 @@ services:
       start_period: 20s
     logging: *default-logging
 
-# Streamlit UAC test container
-  streamlit-uac:
-    build: .
-    command: streamlit run dashboard/pulse_dashboard.py --server.port=${STREAMLIT_SERVER_PORT:-8501}
-    ports: ["8502:8501"]
-    env_file: [.env]
-    depends_on: [pulse-kernel]
-    volumes:
-      - ./:/app
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
     container_name: zookeeper


### PR DESCRIPTION
## Summary
- remove `streamlit-uac` service from docker-compose

## Testing
- `python - <<'PY'
import yaml, sys
from pathlib import Path
try:
    yaml.safe_load(Path('docker-compose.yml').read_text())
    print('docker-compose.yml loaded successfully')
except Exception as e:
    print('error:', e)
PY`
- `docker-compose config -q` *(fails: ModuleNotFoundError: No module named 'distutils')*


------
https://chatgpt.com/codex/tasks/task_b_68c0d262f9c083288c6d6ec713090f52