### PR TITLE
chore: ignore web node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ backend/mt5/.env
 *.zip*
 /dashboard/.cache
 /config/.dbus/session-bus
+
+# Node modules
+web/node_modules/


### PR DESCRIPTION
## Summary
- ignore `web/node_modules` to keep frontend dependencies out of version control

## Testing
- `pytest -q --maxfail=1` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c0d2865c6883289f32ce258b68e670