### PR TITLE
Add Zanalytics dashboard menu and link

### DIFF
--- a/wordpress/themes/twentytwentyfive/functions.php
+++ b/wordpress/themes/twentytwentyfive/functions.php
@@ -156,3 +156,17 @@ if ( ! function_exists( 'twentytwentyfive_format_binding' ) ) :
 		}
 	}
 endif;
+
+// Registers the Zanalytics dashboard menu page.
+function zan_register_dashboard_menu() {
+    add_menu_page(
+        'Dashboard',
+        'Dashboard',
+        'read',
+        'zanalytics-dashboard',
+        function() {
+            echo do_shortcode('[zan_dashboard name="Home" height="800px"]');
+        }
+    );
+}
+add_action( 'admin_menu', 'zan_register_dashboard_menu' );

--- a/wordpress/themes/twentytwentyfive/patterns/header.php
+++ b/wordpress/themes/twentytwentyfive/patterns/header.php
@@ -21,7 +21,9 @@
 			<!-- wp:site-title {"level":0} /-->
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|10"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
 			<div class="wp-block-group">
-				<!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} /-->
+                                <!-- wp:navigation {"overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"right","flexWrap":"wrap"}} -->
+                                <!-- wp:navigation-link {"label":"Dashboard","url":"/zanalytics-dashboard"} /-->
+                                <!-- /wp:navigation -->
 			</div>
 			<!-- /wp:group -->
 		</div>

--- a/wordpress/themes/twentytwentyfive/templates/page-zanalytics-dashboard.html
+++ b/wordpress/themes/twentytwentyfive/templates/page-zanalytics-dashboard.html
@@ -1,0 +1,15 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
+        <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+        <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60)">
+                <!-- wp:shortcode -->
+                [zan_dashboard name="Home" height="800px"]
+                <!-- /wp:shortcode -->
+        </div>
+        <!-- /wp:group -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
## Summary
- register Zanalytics dashboard menu page in Twenty Twenty-Five theme
- expose dashboard link in header navigation
- add template to render dashboard shortcode on front-end

## Testing
- `pytest` *(fails: RuntimeError: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c0d29d74e88328b96da1c20113aeaf