### PR TITLE
chore: update server domain to mcp1

### DIFF
--- a/gpt-action-manifest.json
+++ b/gpt-action-manifest.json
@@ -8,7 +8,7 @@
   },
   "api": {
     "type": "openapi",
-    "url": "https://django2.zanalytics.app/openapi.actions.yaml"
+    "url": "https://mcp1.zanalytics.app/openapi.actions.yaml"
   },
   "logo_url": "https://example.com/logo.png",
   "contact_email": "support@example.com",

--- a/openapi.actions.yaml
+++ b/openapi.actions.yaml
@@ -6,11 +6,11 @@ info:
     Slim spec for agent-facing Actions routed via a single endpoint.
     Keeps the main API under the 30‑operation cap while exposing core verbs.
 servers:
-  - url: https://django2.zanalytics.app
+  - url: https://mcp1.zanalytics.app
 x-openai:
   trusted: true
   permissions:
-    - domain: django2.zanalytics.app
+    - domain: mcp1.zanalytics.app
       always_allow: true
   scopes:
     - read

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,7 +7,7 @@ info:
     Authentication is not required; an optional `X-Pulse-Key` header may be
     enabled later without breaking this contract.
 servers:
-  - url: https://django2.zanalytics.app
+  - url: https://mcp1.zanalytics.app
 paths:
   /api/v1/ping/:
     get:


### PR DESCRIPTION
## Summary
- update API server URLs and domain to mcp1.zanalytics.app
- align gpt-action manifest with new server domain

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c0dc3273648328809b2f444c70b4cc