### PR TITLE
chore: update default django host references

### DIFF
--- a/actions/sse_test.html
+++ b/actions/sse_test.html
@@ -66,7 +66,7 @@
     <header>
       <div class="row">
         <strong>Pulse SSE Test</strong>
-        <input id="base" size="36" placeholder="https://django2.zanalytics.app" />
+        <input id="base" size="36" placeholder="https://mcp1.zanalytics.app" />
         <span class="chip"><input type="checkbox" name="topics" value="whispers" checked /><label>whispers</label></span>
         <span class="chip"><input type="checkbox" name="topics" value="market" checked /><label>market</label></span>
         <span class="chip"><input type="checkbox" name="topics" value="mirror" checked /><label>mirror</label></span>

--- a/dashboard/pages/19_advanced_risk_manager.py
+++ b/dashboard/pages/19_advanced_risk_manager.py
@@ -2277,7 +2277,7 @@ def main():
 
         api_current = st.session_state.get('adv19_api_base', '') or (os.getenv('DJANGO_API_URL', ''))
         with st.expander("Django API Base (override)", expanded=False):
-            api_input = st.text_input("Django API Base URL", value=api_current or '', placeholder="e.g. https://django2.zanalytics.app")
+            api_input = st.text_input("Django API Base URL", value=api_current or '', placeholder="e.g. https://mcp1.zanalytics.app")
             c1, c2, _ = st.columns([1,1,4])
             with c1:
                 if st.button("Apply", key="apply_api_19"):

--- a/dashboard/pages/20_advanced_risk_manager.py
+++ b/dashboard/pages/20_advanced_risk_manager.py
@@ -2231,7 +2231,7 @@ def main():
 
         api_current = st.session_state.get('adv19_api_base', '') or (os.getenv('DJANGO_API_URL', ''))
         with st.expander("Django API Base (override)", expanded=False):
-            api_input = st.text_input("Django API Base URL", value=api_current or '', placeholder="e.g. https://django2.zanalytics.app")
+            api_input = st.text_input("Django API Base URL", value=api_current or '', placeholder="e.g. https://mcp1.zanalytics.app")
             c1, c2, _ = st.columns([1,1,4])
             with c1:
                 if st.button("Apply", key="apply_api_19"):

--- a/dashboard/pages/23_advanced_risk_manager.py
+++ b/dashboard/pages/23_advanced_risk_manager.py
@@ -2231,7 +2231,7 @@ def main():
 
         api_current = st.session_state.get('adv19_api_base', '') or (os.getenv('DJANGO_API_URL', ''))
         with st.expander("Django API Base (override)", expanded=False):
-            api_input = st.text_input("Django API Base URL", value=api_current or '', placeholder="e.g. https://django2.zanalytics.app")
+            api_input = st.text_input("Django API Base URL", value=api_current or '', placeholder="e.g. https://mcp1.zanalytics.app")
             c1, c2, _ = st.columns([1,1,4])
             with c1:
                 if st.button("Apply", key="apply_api_19"):

--- a/dashboard/wiki_dashboard.py
+++ b/dashboard/wiki_dashboard.py
@@ -257,7 +257,7 @@ dashboards = ["Info (Landing)", "Interaction"]
 dashboard = st.sidebar.selectbox("Dashboards", dashboards)
 
 # Persistent Whisperer Panel (context-aware)
-# To eliminate repeated permission prompts for LLM API calls to django2.zanalytics.app,
+# To eliminate repeated permission prompts for LLM API calls to mcp1.zanalytics.app,
 # ensure openapi.actions.yaml defines a trusted connector with always_allow.
 st.sidebar.markdown("<div class='ask-whisperer'>", unsafe_allow_html=True)
 st.sidebar.subheader("Ask Whisperer")


### PR DESCRIPTION
## Summary
- replace django2.zanalytics.app with mcp1.zanalytics.app in SSE test and advanced risk manager pages
- update wiki dashboard comment to new host

## Testing
- `pytest` *(fails: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c0dd7aa8cc8328994f15efce6627fc