### PR TITLE
docs: update domain references to mcp1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ Use this checklist to upload and enable the Whisperer pack for GPT.
 
 2) Configure Actions (OpenAPI)
 - Add an Action with manifest: openapi.actions.yaml
-- Server base URL: your Django host (e.g., https://django2.zanalytics.app)
+- Server base URL: your Django host (e.g., https://mcp1.zanalytics.app)
 - Endpoints exposed via Actions Bus:
   - POST /api/v1/actions/query with verbs: session_boot, trades_recent, trades_history_mt5, whisper_suggest
 

--- a/_schema/GPT_Instructions_1.1.md
+++ b/_schema/GPT_Instructions_1.1.md
@@ -19,7 +19,7 @@ Never invent or assume market prices. Always confirm from a live feed before ref
 
 Preferred sources (in order):
 1) Primary (Pulse) feed — normalized + LLM‑friendly
-- Endpoint: `GET https://django2.zanalytics.app/api/v1/feed/bars-enriched?symbol={SYM}&timeframe=M15&limit=200`
+- Endpoint: `GET https://mcp1.zanalytics.app/api/v1/feed/bars-enriched?symbol={SYM}&timeframe=M15&limit=200`
 - Use the last bar’s `close` as the latest confirmed price for short summaries; otherwise show the time.
 
 2) Backup (Yahoo Finance) feed — direct public source
@@ -35,7 +35,7 @@ Symbol mapping for gold:
 
 Examples:
 - Curl (Pulse):
-  - `curl "https://django2.zanalytics.app/api/v1/feed/bars-enriched?symbol=XAUUSD&timeframe=M15&limit=200"`
+  - `curl "https://mcp1.zanalytics.app/api/v1/feed/bars-enriched?symbol=XAUUSD&timeframe=M15&limit=200"`
 - Curl (Yahoo):
   - `curl "https://query1.finance.yahoo.com/v8/finance/chart/XAUUSD=X?interval=1h&range=60d"`
 
@@ -167,7 +167,7 @@ Options:
 I support whatever you decide."
 
 ## API Integration Notes
-- Base URL (primary): `https://django2.zanalytics.app`
+- Base URL (primary): `https://mcp1.zanalytics.app`
 - Key Endpoints:
   - `/api/v1/mirror/state` — Behavioral metrics
   - `/api/v1/account/info` — Account status

--- a/actions/README.md
+++ b/actions/README.md
@@ -5,13 +5,13 @@ Quick static page to sanity check the Pulse SSE stream.
 
 Usage
 - Open `actions/sse_test.html` in a browser.
-- Set `Base` to your Django host (e.g., `https://django2.zanalytics.app`).
+- Set `Base` to your Django host (e.g., `https://mcp1.zanalytics.app`).
 - Select topics (whispers, market, mirror) and click Connect.
 - Logs show raw SSE event payloads with timestamps.
 
 URL Shortcuts
 - You can deep-link with query params:
-  - `?base=https://django2.zanalytics.app`
+  - `?base=https://mcp1.zanalytics.app`
   - `&topics=mirror,whispers,market`
 
 Notes

--- a/docs/ACTIONS_BUS.md
+++ b/docs/ACTIONS_BUS.md
@@ -77,7 +77,7 @@ Trusted Connector Setup
   x-openai:
     trusted: true
     permissions:
-      - domain: django2.zanalytics.app
+      - domain: mcp1.zanalytics.app
         always_allow: true
     scopes:
       - read

--- a/docs/custom_gpt_instructions.md
+++ b/docs/custom_gpt_instructions.md
@@ -19,7 +19,7 @@ Never invent or assume market prices. Always confirm from a live feed before ref
 
 Preferred sources (in order):
 1) Primary (Pulse) feed — normalized + LLM‑friendly
-- Endpoint: `GET https://django2.zanalytics.app/api/v1/feed/bars-enriched?symbol={SYM}&timeframe=M15&limit=200`
+- Endpoint: `GET https://mcp1.zanalytics.app/api/v1/feed/bars-enriched?symbol={SYM}&timeframe=M15&limit=200`
 - Use the last bar’s `close` as the latest confirmed price for short summaries; otherwise show the time.
 
 2) Backup (Yahoo Finance) feed — direct public source
@@ -35,7 +35,7 @@ Symbol mapping for gold:
 
 Examples:
 - Curl (Pulse):
-  - `curl "https://django2.zanalytics.app/api/v1/feed/bars-enriched?symbol=XAUUSD&timeframe=M15&limit=200"`
+  - `curl "https://mcp1.zanalytics.app/api/v1/feed/bars-enriched?symbol=XAUUSD&timeframe=M15&limit=200"`
 - Curl (Yahoo):
   - `curl "https://query1.finance.yahoo.com/v8/finance/chart/XAUUSD=X?interval=1h&range=60d"`
 
@@ -159,7 +159,7 @@ Options:
 I support whatever you decide."
 
 ## API Integration Notes
-- Base URL (primary): `https://django2.zanalytics.app`
+- Base URL (primary): `https://mcp1.zanalytics.app`
 - Key Endpoints:
   - `/api/v1/mirror/state` — Behavioral metrics
   - `/api/v1/account/info` — Account status

--- a/docs/gpt_llm/GPT_Instructions_1.1.md
+++ b/docs/gpt_llm/GPT_Instructions_1.1.md
@@ -33,7 +33,7 @@ Trigger when `discipline < 60%` OR `losses ≥ 3` OR `risk_used > 90%`.
 - Whisper short and supportive (one line + 2–3 options: break | review rules | reduce size).
 
 ## API Integration Notes
-- Base: `https://django2.zanalytics.app`
+- Base: `https://mcp1.zanalytics.app`
 - Key endpoints:
   - `/api/v1/mirror/state`, `/api/v1/behavioral/patterns`, `/api/v1/account/info`, `/api/v1/account/risk`
   - `/api/v1/market/mini` (VIX/DXY; see seeding)

--- a/docs/gpt_llm/LLM_Integration_Guide.md
+++ b/docs/gpt_llm/LLM_Integration_Guide.md
@@ -3,8 +3,8 @@
 This guide documents the agent‑facing Actions Bus, key REST endpoints, session semantics (SoD), and operational notes so LLMs can interact with Zanalytics Pulse safely and consistently.
 
 ## Base URLs
-- Primary API: `https://django2.zanalytics.app`
-- Slim Actions Spec (OpenAPI): `https://django2.zanalytics.app/openapi.actions.yaml`
+- Primary API: `https://mcp1.zanalytics.app`
+- Slim Actions Spec (OpenAPI): `https://mcp1.zanalytics.app/openapi.actions.yaml`
 
 ## Actions Bus
 - Endpoint: `POST /api/v1/actions/query`

--- a/docs/gpt_llm/actions_bus.md
+++ b/docs/gpt_llm/actions_bus.md
@@ -2,7 +2,7 @@
 
 Purpose: expose a compact set of LLM/agent operations via one endpoint to keep the main OpenAPI under the 30‑operation cap.
 
-Base: `https://django2.zanalytics.app`
+Base: `https://mcp1.zanalytics.app`
 
 Endpoint: `POST /api/v1/actions/query`
 


### PR DESCRIPTION
## Summary
- replace django2.zanalytics.app with mcp1.zanalytics.app across installation and GPT instruction docs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c0dd67a5208328934af8ec31bdc05c