### PR TITLE
docs: correct env template and actions spec references

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This modular design facilitates secure separation of concerns, easy extensibilit
     ```bash
     git clone https://github.com/fotomash/zanalytics-quant.git
     cd zanalytics-quant
-    cp .env.example .env  # Never commit secrets!
+    cp .env.template .env  # Never commit secrets!
     cp backend/mt5/.env.example backend/mt5/.env
     ```
 

--- a/docs/ACTIONS_API_OVERVIEW.md
+++ b/docs/ACTIONS_API_OVERVIEW.md
@@ -18,7 +18,7 @@ It works like a verb bus — you send a JSON object like this:
 …and the system knows exactly what to do with it.
 
 
-All valid actions are described in [`openapi.yaml`](../openapi.yaml), the
+All valid actions are described in [`openapi.actions.yaml`](../openapi.actions.yaml), the
 canonical schema for the verb bus. If a verb isn’t in that spec, it doesn’t
 exist.
 
@@ -108,16 +108,16 @@ API follows a strict plan:
    `"position_close" → handle_position_close()`), never to hard‑coded logic.
 2. **Validate `payload` against the schema** – enforce required fields and block
    unknown keys with Pydantic or an equivalent validator bound to
-   `openapi.yaml`.
+    `openapi.actions.yaml`.
 3. **Add schema before code** – every new action first lands in
-   `openapi.yaml` with an example. Only after that do we implement the handler.
+    `openapi.actions.yaml` with an example. Only after that do we implement the handler.
 4. **Log everything** – persist `{type, payload, user, timestamp}` and return a
    result object noting success or failure.
 5. **No schema drift** – when UI or agent behaviour changes, update the schema
    first, then handlers, then prompts or front‑end code.
 
 Bonus: schema‑aware UIs (Streamlit, Whisperer, etc.) can render available verbs
-directly from `openapi.yaml`.
+directly from `openapi.actions.yaml`.
 
 Example flow:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,6 @@ Current Direction (Active)
 - Architecture (streaming): docs/architecture_pulse_streaming.md
 - Journal envelopes and contracts: docs/journal_envelopes.md
 - Actions API overview: docs/ACTIONS_API_OVERVIEW.md
-- Replay drill quickstart: docs/replay_quickstart.md
 - Kafka sidecar quickstart: ops/kafka/quickstart.md
 - Pulse runtime (gates + detail API): backend/django/app/nexus/pulse/README.md
 - Services (mirror, tick→bar, reconciler): services/README.md


### PR DESCRIPTION
## Summary
- fix README to reference `.env.template`
- drop broken replay quickstart link from docs index
- point Actions API overview to `openapi.actions.yaml`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c0e47163f48328b68383a43ba1afc2