### PR TITLE
Add FastAPI MCP streaming service

### DIFF
--- a/backend/mcp/Dockerfile
+++ b/backend/mcp/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY mcp_server.py .
+CMD ["uvicorn", "mcp_server:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/backend/mcp/mcp_server.py
+++ b/backend/mcp/mcp_server.py
@@ -1,0 +1,61 @@
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import StreamingResponse
+import json
+import asyncio
+import httpx
+import os
+import time
+
+app = FastAPI(title="Zanalytics MCP Server")
+
+INTERNAL_API_BASE = os.getenv("INTERNAL_API_BASE", "http://django:8000")
+
+
+async def generate_mcp_stream():
+    """Generator for NDJSON streaming events."""
+    yield json.dumps({
+        "event": "open",
+        "data": {"status": "ready", "timestamp": time.time()},
+    }) + "\n"
+
+    while True:
+        yield json.dumps({
+            "event": "heartbeat",
+            "data": {"time": time.time(), "server": "mcp1.zanalytics.app"},
+        }) + "\n"
+        await asyncio.sleep(30)
+
+
+@app.get("/mcp")
+async def mcp_stream():
+    return StreamingResponse(
+        generate_mcp_stream(),
+        media_type="application/x-ndjson",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
+
+
+@app.api_route("/exec/{full_path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+async def exec_proxy(request: Request, full_path: str):
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.request(
+                method=request.method,
+                url=f"{INTERNAL_API_BASE}/{full_path}",
+                json=await request.json() if request.method != "GET" else None,
+                headers={k: v for k, v in request.headers.items() if k.lower() not in ["host", "content-length"]},
+            )
+        except httpx.ConnectError:
+            raise HTTPException(status_code=502, detail="Internal API unreachable")
+
+    if resp.status_code >= 400:
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+
+    content_type = resp.headers.get("content-type", "")
+    return resp.json() if content_type.startswith("application/json") else {"status": "ok"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/backend/mcp/requirements.txt
+++ b/backend/mcp/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.104.1
+uvicorn[standard]==0.24.0
+httpx==0.25.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -725,6 +725,28 @@ services:
     networks:
       - default
 
+  mcp:
+    build:
+      context: ./backend/mcp
+    container_name: mcp
+    ports:
+      - "8001:8001"
+    environment:
+      - INTERNAL_API_BASE=http://django:8000
+    depends_on:
+      - django
+    networks:
+      - traefik-public
+      - default
+    labels:
+      <<: *default-labels
+      traefik.enable: true
+      traefik.docker.network: traefik-public
+      traefik.http.routers.mcp.rule: Host(`mcp1.zanalytics.app`)
+      traefik.http.routers.mcp.entrypoints: websecure
+      traefik.http.services.mcp.loadbalancer.server.port: 8001
+    restart: unless-stopped
+
   market-fetcher:
     image: curlimages/curl:8.8.0
     container_name: market-fetcher


### PR DESCRIPTION
## Summary
- implement lightweight FastAPI server exposing `/mcp` NDJSON stream and `/exec` proxy
- add Dockerfile and requirements for MCP service
- wire new `mcp` service into docker-compose with Traefik routing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c0e49b63bc8328bb1dc147d7930da8