### PR TITLE
Restrict Django Traefik routes to root domain

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,12 +227,12 @@ services:
       traefik.enable: true
       traefik.docker.network: traefik-public
 
-      traefik.http.routers.django-http.rule: Host(`${DJANGO_DOMAIN}`)
+      traefik.http.routers.django-http.rule: Host(`${DJANGO_DOMAIN}`) && !Host(`mcp1.${DJANGO_DOMAIN}`)
       traefik.http.routers.django-http.entrypoints: http
       traefik.http.routers.django-http.middlewares: https-redirect
       traefik.http.routers.django-http.service: django-service
 
-      traefik.http.routers.django-https.rule: Host(`${DJANGO_DOMAIN}`)
+      traefik.http.routers.django-https.rule: Host(`${DJANGO_DOMAIN}`) && !Host(`mcp1.${DJANGO_DOMAIN}`)
       traefik.http.routers.django-https.entrypoints: https
       traefik.http.routers.django-https.tls: true
       traefik.http.routers.django-https.tls.certresolver: le


### PR DESCRIPTION
## Summary
- prevent Traefik from routing Django requests from the MCP host by excluding `mcp1.${DJANGO_DOMAIN}` in router rules

## Testing
- `docker compose config` *(fails: command not found)*
- `docker compose restart django traefik` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c0eb91f2108328b2155be8d262f6b2