### PR TITLE
Configure Traefik for MCP over HTTP and HTTPS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -743,7 +743,11 @@ services:
       traefik.enable: true
       traefik.docker.network: traefik-public
       traefik.http.routers.mcp.rule: Host(`mcp1.zanalytics.app`)
-      traefik.http.routers.mcp.entrypoints: websecure
+      traefik.http.routers.mcp.entrypoints: http,https
+      traefik.http.routers.mcp.tls.certresolver: letsencrypt
+      traefik.http.routers.mcp.priority: 200
+      traefik.http.middlewares.mcp-strip.stripprefix.prefixes: /mcp
+      traefik.http.routers.mcp.middlewares: mcp-strip
       traefik.http.services.mcp.loadbalancer.server.port: 8001
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary
- expose MCP service on both HTTP and HTTPS entrypoints
- configure Traefik middleware and TLS cert resolver for MCP router

## Testing
- `docker-compose down mcp traefik && docker-compose up -d --force-recreate mcp traefik` *(fails: Missing mandatory value for "labels" option interpolating {...} in service "traefik": Variable not set)*
- `pre-commit run --files docker-compose.yml` *(fails: pre-commit: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c0ec56f41c832889729d31f17a8345