### PR TITLE
Specify root domain for Django Traefik routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,12 +227,12 @@ services:
       traefik.enable: true
       traefik.docker.network: traefik-public
 
-      traefik.http.routers.django-http.rule: Host(`${DJANGO_DOMAIN}`) && !Host(`mcp1.${DJANGO_DOMAIN}`)
+      traefik.http.routers.django-http.rule: 'HostRegexp(`{domain: zanalytics\.app}`) && !Host(`mcp1.zanalytics.app`)' 
       traefik.http.routers.django-http.entrypoints: http
       traefik.http.routers.django-http.middlewares: https-redirect
       traefik.http.routers.django-http.service: django-service
 
-      traefik.http.routers.django-https.rule: Host(`${DJANGO_DOMAIN}`) && !Host(`mcp1.${DJANGO_DOMAIN}`)
+      traefik.http.routers.django-https.rule: 'HostRegexp(`{domain: zanalytics\.app}`) && !Host(`mcp1.zanalytics.app`)' 
       traefik.http.routers.django-https.entrypoints: https
       traefik.http.routers.django-https.tls: true
       traefik.http.routers.django-https.tls.certresolver: le


### PR DESCRIPTION
## Summary
- refine django service routing to explicitly match `zanalytics.app` and exclude `mcp1`

## Testing
- `docker compose config` *(fails: required variable TRAEFIK_DOMAIN is missing a value)*
- `TRAEFIK_DOMAIN=example.com DJANGO_DOMAIN=zanalytics.app docker compose config` *(fails: required variable GRAFANA_DOMAIN is missing a value)*
- `TRAEFIK_DOMAIN=example.com DJANGO_DOMAIN=zanalytics.app GRAFANA_DOMAIN=example.com docker compose restart django traefik` *(fails: required variable ACME_EMAIL is missing a value)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c0ef4d8e9c83289056474f14a55111