### PR TITLE
fix: update mcp traefik routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -735,11 +735,11 @@ services:
     labels:
       <<: *default-labels
       traefik.enable: true
-      traefik.http.routers.mcp.tls: true
       traefik.docker.network: traefik-public
       traefik.http.routers.mcp.rule: Host(`mcp1.zanalytics.app`)
-      traefik.http.routers.mcp.entrypoints: http,https
+      traefik.http.routers.mcp.entrypoints: websecure  # HTTPS only, no http fallback
       traefik.http.routers.mcp.tls.certresolver: letsencrypt
+      traefik.http.routers.mcp.tls: true
       traefik.http.routers.mcp.priority: 200
       traefik.http.services.mcp.loadbalancer.server.port: 8001
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- tighten Traefik routing for MCP to HTTPS-only `websecure`

## Testing
- `docker compose config` *(fails: `docker: 'compose' is not a docker command`)*
- `docker-compose --no-ansi config --no-interpolate` *(fails: invalid type for labels: traefik.enable true)*
- `docker compose down mcp traefik && docker compose up -d --force-recreate mcp traefik` *(fails: `docker: 'compose' is not a docker command`)*
- `curl -k https://mcp1.zanalytics.app/mcp` *(fails: `{"detail":"Not Found"}`)*
- `docker logs traefik | grep -i mcp` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_68c1119322c483288feec2f7bb9e984d