### PR TITLE
docs: document wyckoff and mcp endpoints

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1,0 +1,73 @@
+# API Endpoints
+
+## Django Wyckoff API
+
+### `POST /api/pulse/wyckoff/score`
+Scores Wyckoff phases and events from bar data.
+
+**Sample payload**
+```json
+{
+  "bars": [
+    {"ts": "2024-01-01T00:00:00Z", "open": 1.0, "high": 1.2, "low": 0.9, "close": 1.1, "volume": 1000},
+    {"ts": "2024-01-01T00:01:00Z", "open": 1.1, "high": 1.3, "low": 1.0, "close": 1.2, "volume": 900}
+  ]
+}
+```
+
+**Expected response**
+```json
+{
+  "score": 42.5,
+  "probs": [0.1, 0.2, 0.7],
+  "events": {"Spring": [false, true], "Upthrust": [false, false]},
+  "reasons": ["phase=Markup"],
+  "explain": {"bb_pctB": 0.0, "vol_z": 0.0, "effort_result": 0.0}
+}
+```
+
+### `GET /api/pulse/wyckoff/health`
+Health check for Wyckoff module.
+
+**Sample payload**: _None_
+
+**Expected response**
+```json
+{
+  "status": "ok",
+  "module": "wyckoff"
+}
+```
+
+## MCP Server
+
+### `GET /mcp`
+Streams NDJSON events from the MCP server.
+
+**Sample payload**: _None_
+
+**Expected response (NDJSON stream)**
+```
+{"event":"open","data":{"status":"ready","timestamp":1693499999.0}}
+{"event":"heartbeat","data":{"time":1693499999.0,"server":"mcp1.zanalytics.app"}}
+...
+```
+
+### `GET|POST|PUT|PATCH|DELETE /exec/{full_path}`
+Proxies requests to the internal Django API located at `INTERNAL_API_BASE`.
+
+**Sample payload (POST)**
+```json
+{
+  "example": "data"
+}
+```
+
+**Expected response**
+```json
+{
+  "status": "ok"
+}
+```
+
+If the proxied endpoint returns JSON, that JSON payload is returned instead.


### PR DESCRIPTION
## Summary
- document Wyckoff scoring and health endpoints in Django
- describe MCP streaming and exec proxy routes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c16b881b948328bffdff69c67afccd