### PR TITLE
docs: add network routing diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,15 @@
+# Architecture
+
+## Network Routing
+
+The diagram below shows external traffic flowing from the host through Traefik to internal services.
+
+```mermaid
+graph LR
+    host[Host] --> traefik[Traefik]
+    traefik --> django[Django:8000]
+    traefik --> mcp[MCP:8001]
+    traefik --> dashboard[Dashboard:8501]
+    traefik --> grafana[Grafana:3000]
+```
+


### PR DESCRIPTION
## Summary
- document host-to-service flow through Traefik

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c16ce301648328bea48954aaf123ce