### PR TITLE
docs: clarify INTERNAL_API_BASE env var

### DIFF
--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -29,7 +29,7 @@ This document lists the environment variables defined in [`.env.template`](../.e
 | `DJANGO_DOMAIN` | `django.localhost` | Update to the domain serving the Django app. | Hostname used by Django for site URLs. |
 | `DJANGO_API_URL` | `http://django:8000` | Modify if the Django API is accessible elsewhere. | Base URL for the Django REST API. |
 | `DJANGO_API_PREFIX` | `/api/v1` | Adjust if the API prefix changes. | Root path prefix for Django API endpoints. |
-| `INTERNAL_API_BASE` | `http://django:8000` | Change to target a different internal Django API. | Base URL used by the MCP server to proxy `/exec` requests to Django. |
+| `INTERNAL_API_BASE` | `http://django:8000` | Override to point at a different internal Django API host. | Base URL the MCP server uses when proxying `/exec` requests to Django. |
 
 ## Frontend / Dashboard Defaults
 | Variable | Default | Override Behavior | Purpose |


### PR DESCRIPTION
## Summary
- clarify INTERNAL_API_BASE default and purpose for MCP `/exec` proxying

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus'; RuntimeError: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c175a3079c8328a138bb3fc1201f0e