### PR TITLE
chore: add actions tracker workflow

### DIFF
--- a/.github/workflows/actions-tracker.yml
+++ b/.github/workflows/actions-tracker.yml
@@ -1,0 +1,20 @@
+name: Actions Tracker
+
+on:
+  push:
+    paths:
+      - 'actions/**'
+      - 'backend/mcp/**'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Generate actions tracker
+        run: python scripts/gen_action_tracker.py
+      - name: Verify actions tracker up to date
+        run: git diff --exit-code docs/actions-tracker.md


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to regenerate actions tracker when actions or MCP code changes
- verify docs/actions-tracker.md remains in sync with generator

## Testing
- `python scripts/gen_action_tracker.py` *(fails: No such file or directory)*
- `pytest -m "not mt5" -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c17b6a1f388328b8e0770662a0c06b