### PR TITLE
docs: clarify action tracker source of truth

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ This repository is migrating from a Redis‑only realtime stack to a dual‑stre
 architecture (Redis + Kafka) with durable, replayable journal events. This hub
 points to the current sources of truth and clearly marks legacy docs.
 
+> **Note:** The [Actions Tracker](actions-tracker.md) is the canonical source for action status and links. When updating actions, keep schemas, implementation code, and documentation in sync with the tracker.
+
 - Status taxonomy
   - Active: production direction; maintained
   - Experimental: shadow mode or behind a flag

--- a/docs/actions-tracker.md
+++ b/docs/actions-tracker.md
@@ -1,5 +1,7 @@
 # Actions Tracker
 
+This file is the single source of truth for action status and links.
+
 Last synced: 2025-09-10T13:20:19+00:00
 
 | Source | Name | Endpoint | Method | Description |


### PR DESCRIPTION
## Summary
- clarify that `docs/actions-tracker.md` is the single source of truth for action status and links
- note in docs README to keep schemas, code, and documentation in sync using the tracker

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c17bbbc58483289af0bf378f68e4e3