### PR TITLE
feat: expose mcp metrics

### DIFF
--- a/backend/mcp/mcp_server.py
+++ b/backend/mcp/mcp_server.py
@@ -1,14 +1,26 @@
 from fastapi import FastAPI, Request, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi.responses import StreamingResponse, Response
 import json
 import asyncio
 import httpx
 import os
 import time
+from prometheus_client import (
+    Counter,
+    Gauge,
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+)
 
 app = FastAPI(title="Zanalytics MCP Server")
 
 INTERNAL_API_BASE = os.getenv("INTERNAL_API_BASE", "http://django:8000")
+
+REQUESTS = Counter("mcp_requests_total", "Total MCP requests", ["endpoint"])
+MCP_UP = Gauge("mcp_up", "MCP server heartbeat status")
+MCP_TIMESTAMP = Gauge(
+    "mcp_last_heartbeat_timestamp", "Unix timestamp of last heartbeat"
+)
 
 
 async def generate_mcp_stream():
@@ -24,6 +36,8 @@ async def generate_mcp_stream():
     # Keep alive with heartbeat every 30 seconds
     while True:
         await asyncio.sleep(30)
+        MCP_UP.set(1)
+        MCP_TIMESTAMP.set(time.time())
         yield json.dumps(
             {
                 "event": "heartbeat",
@@ -34,6 +48,7 @@ async def generate_mcp_stream():
 
 @app.get("/mcp")
 async def mcp_stream():
+    REQUESTS.labels(endpoint="mcp").inc()
     return StreamingResponse(
         generate_mcp_stream(),
         media_type="application/x-ndjson",
@@ -45,6 +60,7 @@ async def mcp_stream():
     "/exec/{full_path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"]
 )
 async def exec_proxy(request: Request, full_path: str):
+    REQUESTS.labels(endpoint="exec").inc()
     async with httpx.AsyncClient() as client:
         try:
             resp = await client.request(
@@ -67,6 +83,11 @@ async def exec_proxy(request: Request, full_path: str):
     return (
         resp.json() if content_type.startswith("application/json") else {"status": "ok"}
     )
+
+
+@app.get("/metrics")
+def metrics():
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 
 if __name__ == "__main__":

--- a/backend/mcp/requirements.txt
+++ b/backend/mcp/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
 httpx==0.25.2
+prometheus_client==0.22.1

--- a/monitoring/configs/prometheus/prometheus.yml
+++ b/monitoring/configs/prometheus/prometheus.yml
@@ -41,3 +41,8 @@ scrape_configs:
       - targets: ["cadvisor:8080"]
         labels:
           container: "cadvisor"
+  - job_name: mcp
+    static_configs:
+      - targets: ["mcp:8001"]
+        labels:
+          container: "mcp"

--- a/monitoring/configs/promtail/promtail.yaml
+++ b/monitoring/configs/promtail/promtail.yaml
@@ -26,6 +26,10 @@ scrape_configs:
         target_label: 'logstream'
       - source_labels: ['__meta_docker_container_label_logging_jobname']
         target_label: 'job'
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/mcp'
+        target_label: 'job'
+        replacement: 'mcp'
     pipeline_stages:
       - cri: {}
       - multiline:


### PR DESCRIPTION
## Summary
- instrument MCP server with Prometheus counters and gauges
- add metrics endpoint and heartbeat tracking
- configure Prometheus and Promtail to scrape MCP service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c18012b25c8328b5608a8ee220f01a