### PR TITLE
docs: complete action tracker references

### DIFF
--- a/docs/actions-tracker.md
+++ b/docs/actions-tracker.md
@@ -16,17 +16,17 @@ Last synced: 2025-09-10T13:20:19+00:00
 | OPENAI_ACTIONS | trade_open | /trade/open | POST | Open a new trading position |
 | OPENAI_ACTIONS | trade_close | /trade/close | POST | Close an existing trading position |
 | OPENAI_ACTIONS | trade_modify | /trade/modify | POST | Modify stop-loss or take-profit for a position |
-| mcp_server | /mcp | /mcp | GET |  |
-| mcp_server | /exec/{full_path:path} | /exec/{full_path:path} | GET, POST, PUT, PATCH, DELETE |  |
+| mcp_server | /mcp | /mcp | GET | Stream MCP events via NDJSON heartbeat ([endpoints.md](endpoints.md)) |
+| mcp_server | /exec/{full_path:path} | /exec/{full_path:path} | GET, POST, PUT, PATCH, DELETE | Proxy request to internal API ([endpoints.md](endpoints.md)) |
 
 Tracks active and planned actions with their schema references and documentation.
 
 | Action | Schema Path | Authoritative Doc | Status | Core Function | Why | Future | Retired |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `/session/boot` | — | — | Draft | Initialize agent session | Provide handshake and capabilities | Define schema and auth flow | No |
-| `/exec/{cmd}` | — | [endpoints.md](endpoints.md) | Stable | Proxy requests to internal API | Expose single entry point for agent commands | Add auth and logging | No |
-| `/tool/search` | — | — | Planned | Search available tools | Allow agents to discover functionality | Schema under development | No |
-| `/tool/fetch` | — | — | Planned | Retrieve data using a specific tool | Fetch resources for analysis | Schema under development | No |
-| `/mcp` | — | [endpoints.md](endpoints.md) | Stable | Stream MCP events | Provide real-time NDJSON heartbeat | Stream more event types | No |
+| `/session/boot` | `openapi.actions.yaml#/components/schemas/SessionBootRequest` | [ACTIONS_BUS.md](ACTIONS_BUS.md) | Draft | Initialize agent session | Provide handshake and capabilities | Define schema and auth flow | No |
+| `/exec/{cmd}` | N/A | [endpoints.md](endpoints.md) | Stable | Proxy requests to internal API | Expose single entry point for agent commands | Add auth and logging | No |
+| `/tool/search` | `openapi.actions.yaml#/paths/~1tool~1search` | [ACTIONS_API_OVERVIEW.md](ACTIONS_API_OVERVIEW.md) | Planned | Search available tools | Allow agents to discover functionality | Schema under development | No |
+| `/tool/fetch` | `openapi.actions.yaml#/paths/~1tool~1fetch` | [ACTIONS_API_OVERVIEW.md](ACTIONS_API_OVERVIEW.md) | Planned | Retrieve data using a specific tool | Fetch resources for analysis | Schema under development | No |
+| `/mcp` | N/A | [endpoints.md](endpoints.md) | Stable | Stream MCP events | Provide real-time NDJSON heartbeat | Stream more event types | No |
 | `/api/v1/positions/modify` | `openapi.yaml#/paths/~1api~1v1~1positions~1modify` | [POSITIONS_AND_ORDERS.md](POSITIONS_AND_ORDERS.md) | Stable | Modify SL/TP for an existing position | Adjust risk on open trades | Expand to volume modifications | No |
-| `/api/v1/risk/query` | — | — | Planned | Query risk metrics | Assess risk exposure | Schema pending | No |
+| `/api/v1/risk/query` | `openapi.yaml#/paths/~1api~1v1~1risk~1query` | [VERBS_CATALOG.md](VERBS_CATALOG.md) | Planned | Query risk metrics | Assess risk exposure | Schema pending | No |


### PR DESCRIPTION
## Summary
- document MCP proxy endpoints and stream in actions tracker
- fill schema path and authoritative doc references for planned actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c181c8facc8328af32085c9692349d