### PR TITLE
docs: note auto-deploy of info site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Static Info Site
 - No WordPress backend or other dynamic CMS is involved.
 - Deploy by serving the static content via tools like Streamlit or MkDocs behind Traefik.
 
+> Editing any `docs/*.md` file and pushing changes updates the live site within seconds. See full setup: [docs/info-site.md](info-site.md).
 
 Return to [project README](../README.md)
 


### PR DESCRIPTION
## Summary
- highlight that editing any `docs/*.md` file automatically updates the info site within seconds

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus'; RuntimeError: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c182b4d99c8328947146d5b54c0087