### PR TITLE
docs: add monitoring overview

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Current Direction (Active)
 - Pulse runtime (gates + detail API): backend/django/app/nexus/pulse/README.md
 - Services (mirror, tick→bar, reconciler): services/README.md
 - Dashboard pages index: dashboard/pages/README.md
+- Monitoring stack: docs/monitoring.md
 
 Legacy / Retired (kept for history)
 -----------------------------------

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,3 +26,8 @@ graph LR
     mt5 --> redis
 ```
 
+
+## Monitoring
+
+For metrics collection, dashboards, and alerts, see [monitoring.md](monitoring.md).
+

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,27 @@
+# Monitoring
+
+This project uses a Prometheus, Grafana, and Alertmanager stack to observe
+application and infrastructure health.
+
+## Prometheus scraping
+
+Prometheus pulls metrics from application services, the host node, and running
+containers. Each component exposes a `/metrics` endpoint. Prometheus scrapes
+these endpoints at regular intervals and stores the results in its time‑series
+database for querying and alert evaluation.
+
+## Grafana dashboards
+
+Grafana connects to Prometheus as a data source. Prebuilt dashboards visualize
+node statistics, container performance, and application metrics. The Grafana UI
+is available at `http://localhost:3000`, and additional dashboards can be added
+or customized to suit operational needs.
+
+## Alertmanager behavior
+
+Prometheus rules evaluate metrics and fire alerts when conditions are met.
+Alertmanager receives these alerts, groups and de‑duplicates them, and routes
+notifications to configured receivers such as the Uncomplicated Alert Receiver
+UI. Alerts persist until the triggering condition clears or they are
+acknowledged.
+


### PR DESCRIPTION
## Summary
- add monitoring overview for Prometheus, Grafana and Alertmanager
- link monitoring docs from architecture and doc hub

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c184d4c6b48328852e62f96b97d575