### PR TITLE
docs: document monitoring ports

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -125,6 +125,13 @@ ALERTS_TOXICITY_LIMIT=0.30
 ALERTS_DD_INTRADAY_WARN=0.025
 
 # -----------------------------------------------------------------------------
+# MONITORING PORTS (Optional - uses defaults if not set)
+# -----------------------------------------------------------------------------
+PROMETHEUS_PORT=9090
+ALERTMANAGER_PORT=9093
+GRAFANA_PORT=3000
+
+# -----------------------------------------------------------------------------
 # MONITORING VERSIONS (Optional - uses defaults if not set)
 # -----------------------------------------------------------------------------
 GRAFANA_VERSION=11.0.0

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -112,6 +112,13 @@ This document lists the environment variables defined in [`.env.template`](../.e
 | `ALERTS_TOXICITY_LIMIT` | `0.30` | Tune to cap toxicity levels allowed. | Maximum acceptable toxicity before alerting. |
 | `ALERTS_DD_INTRADAY_WARN` | `0.025` | Change to control drawdown warning level. | Intraday drawdown fraction that triggers a warning. |
 
+## Monitoring Ports
+| Variable | Default | Override Behavior | Purpose |
+| --- | --- | --- | --- |
+| `PROMETHEUS_PORT` | `9090` | Adjust if Prometheus should listen on a different port. | Port where Prometheus serves metrics. |
+| `ALERTMANAGER_PORT` | `9093` | Change if Alertmanager should listen on another port. | Port for the Alertmanager web UI and API. |
+| `GRAFANA_PORT` | `3000` | Set to expose Grafana on an alternate port. | Port for accessing the Grafana dashboard. |
+
 ## Monitoring Versions
 | Variable | Default | Override Behavior | Purpose |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## Summary
- document GRAFANA_PORT, PROMETHEUS_PORT and ALERTMANAGER_PORT in environment reference
- add monitoring port defaults to `.env.template`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c185148d5c8328a468a77a3eed7e76