### PR TITLE
docs: document streamlit info site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Static Info Site
 - The public info site is a static hub synced directly from this repository's `docs/` directory.
 - No WordPress backend or other dynamic CMS is involved.
 - Deploy by serving the static content via tools like Streamlit or MkDocs behind Traefik.
+- Streamlit setup details are in [streamlit.md](streamlit.md).
 
 > Editing any `docs/*.md` file and pushing changes updates the live site within seconds. See [info-site.md](info-site.md) for details on content sourcing, deployment, and auto-sync.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@ graph LR
     mt5 --> redis
 ```
 
+Traefik also routes requests to the Streamlit info site on port `8501`; see [streamlit.md](streamlit.md) for details.
 
 ## Monitoring
 

--- a/docs/streamlit.md
+++ b/docs/streamlit.md
@@ -1,0 +1,27 @@
+# Streamlit Info Site
+
+The repository uses a minimal Streamlit app to present Markdown files from `docs/` as a public information site.
+
+## Default Port
+
+- The app listens on port `8501` inside the container.
+
+## Traefik Routing
+
+A typical `docker-compose` setup routes HTTPS traffic through Traefik to the Streamlit container:
+
+```yaml
+volumes:
+  - ./docs:/app/docs:ro
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.info.rule=Host(`info.example.com`)"
+  - "traefik.http.services.info.loadbalancer.server.port=8501"
+```
+
+## Docs Mount
+
+- The container mounts the repository's `docs/` directory read-only.
+- Each Markdown file becomes a page on the public info site.
+
+This setup keeps the site in sync with the repository; pushing changes to `docs/` updates the live content.


### PR DESCRIPTION
## Summary
- add `docs/streamlit.md` explaining the Streamlit app's purpose, port 8501, Traefik routing, and docs mount
- link the Streamlit doc from the docs README and architecture overview

## Testing
- `pytest` *(fails: RuntimeError populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c18633dfd08328aeea8ffda48047b7