### PR TITLE
docs: add API security guide

### DIFF
--- a/docs/api-security.md
+++ b/docs/api-security.md
@@ -1,0 +1,33 @@
+# API Security
+
+## Setting and rotating `X-API-Key`
+
+- Set the `X-API-Key` value as an environment variable in production deployments. Avoid hard-coding it in source code or configuration files.
+- Rotate the key on a regular schedule and update the environment variable accordingly.
+- For local development you can use a test value such as `dev-key-123`.
+
+## Public vs. protected endpoints
+
+- `/mcp` is a public heartbeat endpoint and requires no authentication.
+- Other routes, like `/api/v1/actions/read` or `/exec/...`, must include the `X-API-Key` header.
+
+## Curl example
+
+```bash
+curl -s -H "X-API-Key: dev-key-123" http://localhost:8080/api/v1/actions/read
+# Omitting the header returns 401 Unauthorized
+curl -s http://localhost:8080/api/v1/actions/read
+```
+
+## OpenAI connector setup
+
+In the OpenAI connector, configure:
+
+- **Authentication → Custom**
+- **Header Name:** `X-API-Key`
+- **Value:** `dev-key-123`
+
+## Whisperer sessions
+
+Upon successful authentication, the Whisperer component can initiate sessions safely.
+


### PR DESCRIPTION
## Summary
- document X-API-Key management and rotation
- clarify public vs authenticated endpoints
- add examples for curl and OpenAI connector config

## Testing
- `pytest` *(fails: RuntimeError: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1874862f8832894f1aa8bae9cb165