### PR TITLE
Use env-driven API key for MCP server

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -35,6 +35,12 @@ DJANGO_API_URL=http://django:8000
 DJANGO_API_PREFIX=/api/v1
 
 # -----------------------------------------------------------------------------
+# MCP SERVER SETTINGS
+# -----------------------------------------------------------------------------
+# API key required for MCP requests; set to a strong secret in production
+MCP_API_KEY=your_mcp_api_key_here
+
+# -----------------------------------------------------------------------------
 # FRONTEND/DASHBOARD DEFAULTS
 # -----------------------------------------------------------------------------
 # Default symbol for Streamlit pages if API doesn't return symbols

--- a/backend/mcp/mcp_server.py
+++ b/backend/mcp/mcp_server.py
@@ -16,7 +16,8 @@ app = FastAPI(title="Zanalytics MCP Server")
 
 INTERNAL_API_BASE = os.getenv("INTERNAL_API_BASE", "http://django:8000")
 
-HEADERS = {"X-API-Key": "dev-key-123"}
+# API key expected in incoming requests; empty string by default
+API_KEY = os.environ.get("MCP_API_KEY", "")
 
 REQUESTS = Counter("mcp_requests_total", "Total MCP requests", ["endpoint"])
 MCP_UP = Gauge("mcp_up", "MCP server heartbeat status")
@@ -29,7 +30,7 @@ MCP_TIMESTAMP = Gauge(
 async def check_key(request: Request, call_next):
     if request.url.path == "/mcp":
         return await call_next(request)
-    if request.headers.get("X-API-Key") != HEADERS["X-API-Key"]:
+    if request.headers.get("X-API-Key") != API_KEY:
         return JSONResponse(
             status_code=401, content={"error": "Unauthorized - invalid API key"}
         )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -670,6 +670,7 @@ services:
     container_name: mcp
     environment:
       - INTERNAL_API_BASE=http://django:8000
+      - MCP_API_KEY=${MCP_API_KEY:-}
     depends_on:
       - django
     networks:

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -30,6 +30,7 @@ This document lists the environment variables defined in [`.env.template`](../.e
 | `DJANGO_API_URL` | `http://django:8000` | Modify if the Django API is accessible elsewhere. | Base URL for the Django REST API. |
 | `DJANGO_API_PREFIX` | `/api/v1` | Adjust if the API prefix changes. | Root path prefix for Django API endpoints. |
 | `INTERNAL_API_BASE` | `http://django:8000` | Override to point at a different internal Django API host. | Base URL the MCP server uses when proxying `/exec` requests to Django. |
+| `MCP_API_KEY` | _(empty)_ | Set to a strong secret in production. | API key the MCP server expects in `X-API-Key` header. |
 
 ## Frontend / Dashboard Defaults
 | Variable | Default | Override Behavior | Purpose |


### PR DESCRIPTION
## Summary
- Load MCP API key from MCP_API_KEY env var and check header against it
- Add MCP_API_KEY to env template and docker-compose
- Document MCP_API_KEY in env reference docs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c1894492e08328a88b0cb38b99b4b0