### PR TITLE
docs: clarify action status legend

### DIFF
--- a/docs/actions-tracker.md
+++ b/docs/actions-tracker.md
@@ -4,20 +4,12 @@ This file is the single source of truth for action status and links.
 
 Last synced: 2025-09-10T13:20:19+00:00
 
-| Source | Name | Endpoint | Method | Description |
-| --- | --- | --- | --- | --- |
-| OPENAI_ACTIONS | actions_read | /api/v1/actions/read | GET | Query a read-only action via alias endpoint |
-| OPENAI_ACTIONS | actions_query | /api/v1/actions/query | GET | Query a read-only action |
-| OPENAI_ACTIONS | actions_execute | /api/v1/actions/query | POST | Execute an action via the Actions Bus |
-| OPENAI_ACTIONS | position_close | /api/v1/positions/close | POST | Close full or partial position |
-| OPENAI_ACTIONS | position_modify | /api/v1/positions/modify | POST | Modify SL/TP for an existing position |
-| OPENAI_ACTIONS | position_modify_by_ticket | /api/v1/positions/{ticket}/modify | POST | Modify SL/TP for an existing position by ticket path |
-| OPENAI_ACTIONS | position_hedge | /api/v1/positions/hedge | POST | Open an opposite-side hedge order for a position |
-| OPENAI_ACTIONS | trade_open | /trade/open | POST | Open a new trading position |
-| OPENAI_ACTIONS | trade_close | /trade/close | POST | Close an existing trading position |
-| OPENAI_ACTIONS | trade_modify | /trade/modify | POST | Modify stop-loss or take-profit for a position |
-| mcp_server | /mcp | /mcp | GET | Stream MCP events via NDJSON heartbeat ([endpoints.md](endpoints.md)) |
-| mcp_server | /exec/{full_path:path} | /exec/{full_path:path} | GET, POST, PUT, PATCH, DELETE | Proxy request to internal API ([endpoints.md](endpoints.md)) |
+## Status Legend
+
+- **Stable**: Ready for general use
+- **Draft**: Under active development
+- **Planned**: Accepted but not yet implemented
+- **Retired**: Removed from active use
 
 Tracks active and planned actions with their schema references and documentation.
 


### PR DESCRIPTION
## Summary
- add status legend for action lifecycle
- remove redundant action table

## Testing
- `pytest` *(fails: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1898cda7483289af3c1c2271976b8