### PR TITLE
docs: update audit with latest docs

### DIFF
--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,22 +1,31 @@
 # Documentation Audit
 
-- [ ] ACTIONS_API_OVERVIEW.md — Last reviewed: 2025-09-10
-- [ ] ACTIONS_BUS.md — Last reviewed: 2025-09-10
-- [ ] Behavioral_Gates.md — Last reviewed: 2025-09-08
-- [ ] DEPLOYMENT_CHECKLIST.md — Last reviewed: 2025-09-08
-- [ ] Donut_Confluence_Spec.md — Last reviewed: 2025-09-08
-- [ ] HowTo_Confluence_Scorer.md — Last reviewed: 2025-09-10
-- [ ] JOURNALING.md — Last reviewed: 2025-09-08
-- [ ] POSITIONS_AND_ORDERS.md — Last reviewed: 2025-09-09
-- [ ] README.md — Last reviewed: 2025-09-10
-- [ ] SoD_Equity_Snapshot.md — Last reviewed: 2025-09-08
-- [ ] VERBS_CATALOG.md — Last reviewed: 2025-09-10
-- [ ] WHISPERER.md — Last reviewed: 2025-09-10
-- [ ] Zanalytics Pulse_ Final Design & Innovation Brief.md — Last reviewed: 2025-09-08
-- [ ] architecture.md — Last reviewed: 2025-09-10
-- [ ] architecture_pulse_streaming.md — Last reviewed: 2025-09-08
-- [ ] custom_gpt_instructions.md — Last reviewed: 2025-09-10
-- [ ] endpoints.md — Last reviewed: 2025-09-10
-- [ ] env-reference.md — Last reviewed: 2025-09-10
-- [ ] journal_envelopes.md — Last reviewed: 2025-09-08
-- [ ] troubleshooting.md — Last reviewed: 2025-09-10
+- [x] ACTIONS_API_OVERVIEW.md — Last reviewed: 2025-09-10
+- [x] ACTIONS_BUS.md — Last reviewed: 2025-09-10
+- [x] Behavioral_Gates.md — Last reviewed: 2025-09-08
+- [x] DEPLOYMENT_CHECKLIST.md — Last reviewed: 2025-09-08
+- [x] Donut_Confluence_Spec.md — Last reviewed: 2025-09-08
+- [x] HowTo_Confluence_Scorer.md — Last reviewed: 2025-09-10
+- [x] JOURNALING.md — Last reviewed: 2025-09-08
+- [x] POSITIONS_AND_ORDERS.md — Last reviewed: 2025-09-09
+- [x] README.md — Last reviewed: 2025-09-10
+- [x] SoD_Equity_Snapshot.md — Last reviewed: 2025-09-08
+- [x] VERBS_CATALOG.md — Last reviewed: 2025-09-10
+- [x] WHISPERER.md — Last reviewed: 2025-09-10
+- [x] Zanalytics Pulse_ Final Design & Innovation Brief.md — Last reviewed: 2025-09-08
+- [x] architecture.md — Last reviewed: 2025-09-10
+- [x] architecture_pulse_streaming.md — Last reviewed: 2025-09-08
+- [x] custom_gpt_instructions.md — Last reviewed: 2025-09-10
+- [x] endpoints.md — Last reviewed: 2025-09-10
+- [x] env-reference.md — Last reviewed: 2025-09-10
+- [x] journal_envelopes.md — Last reviewed: 2025-09-08
+- [x] troubleshooting.md — Last reviewed: 2025-09-10
+
+- [ ] actions-tracker.md — Last reviewed: 2025-09-10
+- [ ] api-security.md — Last reviewed: 2025-09-10
+- [ ] full-setup-guide.md — Last reviewed: 2025-09-10
+- [ ] info-site.md — Last reviewed: 2025-09-10
+- [ ] mcp-audit-trail.md — Last reviewed: 2025-09-10
+- [ ] monitoring.md — Last reviewed: 2025-09-10
+- [ ] streamlit.md — Last reviewed: 2025-09-10
+- [ ] trading-flow.md — Last reviewed: 2025-09-10


### PR DESCRIPTION
## Summary
- mark previously reviewed docs as completed in `docs/audit.md`
- track additional documentation with last review dates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c18ae435ac8328abc7ea1eea47b6fe