### PR TITLE
docs: add auth guide and clarify MCP_API_KEY

### DIFF
--- a/docs/api-security.md
+++ b/docs/api-security.md
@@ -2,8 +2,8 @@
 
 ## Setting and rotating `X-API-Key`
 
-- Set the `X-API-Key` value as an environment variable in production deployments. Avoid hard-coding it in source code or configuration files.
-- Rotate the key on a regular schedule and update the environment variable accordingly.
+- Set the `X-API-Key` value in an environment variable named `MCP_API_KEY`. Avoid hard-coding it in source code or configuration files.
+- Rotate the key on a regular schedule and update `MCP_API_KEY` accordingly.
 - For local development you can use a test value such as `dev-key-123`.
 
 ## Public vs. protected endpoints
@@ -18,6 +18,8 @@ curl -s -H "X-API-Key: dev-key-123" http://localhost:8080/api/v1/actions/read
 # Omitting the header returns 401 Unauthorized
 curl -s http://localhost:8080/api/v1/actions/read
 ```
+
+See [auth](auth.md) for additional authentication examples and key rotation steps.
 
 ## OpenAI connector setup
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,32 @@
+# Authentication
+
+This guide explains how to authenticate requests to the MCP server. For more background see [API Security](api-security.md).
+
+## Example requests
+
+The `X-API-Key` header must be supplied for most endpoints. Use a development key such as `dev-key-123` during local testing.
+
+```bash
+# Public heartbeat
+curl -s http://localhost:8080/mcp
+
+# Authenticated action
+curl -s -H "X-API-Key: dev-key-123" \
+  http://localhost:8080/api/v1/actions/read
+```
+
+## Endpoint rules
+
+- `/mcp` is unauthenticated and acts as a heartbeat.
+- `/api/v1/actions/...` and similar routes require the `X-API-Key` header.
+
+## Rotating the key
+
+1. Set a new value for `MCP_API_KEY` in your `.env` file.
+2. Run `docker compose up --build mcp` to rebuild the service with the updated key.
+3. Update the key in the connector UI so clients send the new header.
+
+## Why this matters
+
+Rotating the key prevents "Error talking to connector" pop-ups while keeping the heartbeat endpoint public.
+


### PR DESCRIPTION
## Summary
- document authentication flow and API key rotation steps
- explain MCP_API_KEY usage in API security guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c18d57685c8328ad4eac080f414b5a