### PR TITLE
docs: add FAQ entry for Docker container issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,15 @@ A: Real-time data is cached in Redis and long-term data is stored in Postgres. S
 **Q: How can I add a new feature or signal?**  
 A: Extend or edit the scripts in `utils/` and trigger the enrichment process.
 
-**Q: What if the dashboard is blank?**  
+**Q: What if the dashboard is blank?**
 A: Double-check your API/DB containers, verify enrichment, and confirm `.env` credentials.
+
+**Q: Docker containers fail to build/start.**
+A:
+1. Verify your Docker installation and version.
+2. Rebuild images without cache using `docker-compose build --no-cache`.
+3. Check container output with `docker-compose logs`.
+4. Ensure required ports are free to avoid conflicts.
 
 ---
 


### PR DESCRIPTION
## Summary
- add FAQ entry explaining what to do when Docker containers fail to build or start

## Testing
- `pytest` (failed: populate() isn't reentrant)
- `pytest tests/test_analyzers.py`


------
https://chatgpt.com/codex/tasks/task_b_68c193aafad083288c6ebf76bd0f878b