### PR TITLE
feat: add documentation validation script

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,3 +51,11 @@ Static Info Site
 
 Return to [project README](../README.md)
 
+
+## Quickstart
+
+Run this:
+
+```bash
+docker compose up
+```

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -19,3 +19,5 @@ The server reads the key from the `MCP_API_KEY` environment variable. To rotate 
 2. Restart the service so it picks up the new key, e.g. `docker compose up --build mcp`.
 3. Update clients to send the new `X-API-Key` header.
 
+
+Last validated: 2025-09-10 15:07:51Z

--- a/docs/env-plan.md
+++ b/docs/env-plan.md
@@ -1,0 +1,6 @@
+Future: MCP Key Rotation & Multi-MCP Support
+
+- Keys : Use API_KEY_MCP1, API_KEY_MCP2, ... – one per instance.
+- Why : Clear, scalable. MCP1 → MCP5 already reserved in DNS. When we migrate (e.g., AWS → GCP), just flip DNS and rotate key.
+- How : In code, get: API_KEY = os.getenv(f'API_KEY_MCP{instance_num}', 'fallback')
+- Transition : Run both stacks, send traffic

--- a/docs/validate.sh
+++ b/docs/validate.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# docs/validate.sh – Auto-check doc accuracy
+
+set -e
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo "Checking docs vs code..."
+
+# 1. Auth key: should match what's in code or .env
+CODE_LINE=$(grep -E "API_KEY[[:space:]]*=" backend/mcp/mcp_server.py 2>/dev/null | head -n 1)
+ENV_KEY=$(grep -E '^MCP_API_KEY=' .env 2>/dev/null | cut -d= -f2-)
+if [[ -z "$ENV_KEY" ]]; then
+  ENV_KEY=$(grep -E '^MCP_API_KEY=' .env.template 2>/dev/null | cut -d= -f2-)
+fi
+
+if echo "$CODE_LINE" | grep -q "dev-key-123"; then
+  echo -e "${GREEN}Hardcoded dev key found – OK for testing.${NC}"
+else
+  if [[ -n "$ENV_KEY" && "$CODE_LINE" =~ os.environ.get|os.getenv ]]; then
+    echo -e "${GREEN}Key pulled from .env – production-ready.${NC}"
+  else
+    echo -e "${RED}Key missing or inconsistent – fix .env or code.${NC}"
+    exit 1
+  fi
+fi
+
+# 2. Last validated timestamp – auto-update
+TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%SZ')
+sed -i'' -e "s/Last validated: .*/Last validated: $TIMESTAMP/" docs/auth.md
+echo "Updated docs/auth.md → Last validated: $TIMESTAMP"
+
+# 3. Granularity test – simulate pick up and run
+if grep -q 'Run this:' docs/README.md; then
+  echo -e "${GREEN}README has boot instructions – granular enough.${NC}"
+else
+  echo -e "${RED}Add 'Run this' block to README – someone needs a map.${NC}"
+  exit 1
+fi
+
+# 4. Future naming – bake it in
+if grep -q 'API_KEY_MCP1' docs/env-plan.md 2>/dev/null; then
+  echo -e "${GREEN}Future key naming documented.${NC}"
+else
+  echo "Adding vision to docs/env-plan.md..."
+  cat >> docs/env-plan.md <<'EOS'
+Future: MCP Key Rotation & Multi-MCP Support
+
+- Keys : Use API_KEY_MCP1, API_KEY_MCP2, ... – one per instance.
+- Why : Clear, scalable. MCP1 → MCP5 already reserved in DNS. When we migrate (e.g., AWS → GCP), just flip DNS and rotate key.
+- How : In code, get: API_KEY = os.getenv(f'API_KEY_MCP{instance_num}', 'fallback')
+- Transition : Run both stacks, send traffic
+EOS
+fi
+


### PR DESCRIPTION
## Summary
- add docs/validate.sh to check docs against code and env
- document key rotation plan and README quickstart
- track auth doc validation timestamp

## Testing
- `./docs/validate.sh`


------
https://chatgpt.com/codex/tasks/task_b_68c193a2ae588328b5b4a9d121f143a0