### PR TITLE
docs: link to central documentation hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Trader‑first analytics, risk, and execution — backed by MT5, Django, Redis, Postgres, and Streamlit. Now with LLM‑native Actions and safe position control (partials, scaling, hedging).
 
+For deeper architecture insights and API details, visit the [docs README](docs/README.md), the central hub for extended documentation.
+
 ## Contents
 - [What's Inside](#whats-inside)
 - [Architecture](#architecture)


### PR DESCRIPTION
## Summary
- reference docs/README.md from main README as the central hub for architecture and API docs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c194f3bf3c83288ffac1d590df93b4