### PR TITLE
docs: fix dashboard step formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Unauthorized use, distribution, or copying is prohibited and will be prosecuted.
 1. **Create a new Python file** in `dashboard/` (e.g. `CustomDashboard.py`).
 2. **Import data** from the Django API, Redis, or load a Parquet snapshot.
 3. **Add custom Streamlit widgets, charts, or analytics.**
-4. **Mount in Docker, rebuild, and access from the dashboard UI.
+4. **Mount in Docker, rebuild, and access from the dashboard UI**.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix formatting of final step in "Advanced Usage: Adding a New Dashboard" section
- ensure bullet list renders correctly by closing emphasis before period

## Testing
- `python -m markdown README.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c194f00e9c8328bbc505b3a86dcd67