### PR TITLE
docs: add FAQ entry for web UI build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,9 @@ A:
 **Q: Install or build fails due to missing packages or version conflicts?**
 A: Ensure you're using the supported Python version, then install dependencies with `poetry install` or `pip install -r requirements.txt`. If issues persist, clear cached wheels (e.g., `pip cache purge`) and try again.
 
+**Q: The web UI won't compile or `npm start` fails.**
+A: Delete `web/node_modules`, run `npm install` or `npm ci`, and confirm you're using the Node.js version required by the project.
+
 
 **Q: How do I reset the containers when data gets corrupted or outdated?**
 A:


### PR DESCRIPTION
## Summary
- Document troubleshooting steps when web UI fails to compile or `npm start` fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c197a074dc8328b2c687fc26346b40