### PR TITLE
docs: add FAQ for container reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ A: Ensure you're using the supported Python version, then install dependencies w
 **Q: How do I reset the containers when data gets corrupted or outdated?**
 A:
 1. Stop and remove containers and volumes: `docker-compose down -v`.
-2. Remove any orphan containers: `docker-compose down --remove-orphans`.
+2. Remove any orphan containers: `docker container prune -f`.
 3. Rebuild and start fresh containers: `docker-compose up --build`.
 4. Rerun database migrations if applicable.
 


### PR DESCRIPTION
## Summary
- document container reset steps in FAQ

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c199939c188328b84caae38c79bca1