### PR TITLE
Kill stray pulse_kernel before service restart

### DIFF
--- a/change-ritual.sh
+++ b/change-ritual.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Stop any stray pulse_kernel processes so they don't interfere
+pkill -f pulse_kernel || true
+echo "Stopped stray pulse_kernel processes"
+
+# Start new services
+# (replace with specific service start commands as needed)
+docker-compose up -d "$@"


### PR DESCRIPTION
## Summary
- add `change-ritual.sh` script that kills stray `pulse_kernel` processes before bringing up services
- log cleanup action and continue even when no kernel is running

## Testing
- `bash -n change-ritual.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c19c0030bc8328abff708e0508ac58