### PR TITLE
docs: rename contents heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Trader‑first analytics, risk, and execution — backed by MT5, Django, Redis, 
 
 For deeper architecture insights and API details, visit the [docs README](docs/README.md), the central hub for extended documentation.
 
-## Contents
+## Table of Contents
 - [What's Inside](#whats-inside)
 - [Architecture](#architecture)
 - [System Overview](#system-overview)


### PR DESCRIPTION
## Summary
- rename top-level `Contents` heading to `Table of Contents`
- keep an updated anchor list for all README sections

## Testing
- `pytest tests/test_analyzers.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c19c584618832891789706a3cd7c53