### PR TITLE
docs: remove legacy index reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,7 @@ Current Direction (Active)
 Legacy / Retired (kept for history)
 -----------------------------------
 
-See docs/LEGACY_INDEX.md for a curated list of older guides and one‑liners on
-why they’re retired.
+Older guides remain in this directory for historical reference and are no longer maintained.
 
 Flags and Defaults
 ------------------


### PR DESCRIPTION
## Summary
- remove outdated docs/LEGACY_INDEX.md link from docs/README

## Testing
- `pytest` *(fails: RuntimeError: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c19fe6720883288192353dc640709b