### PR TITLE
Align requirements with constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,9 @@ djangorestframework==3.15.2
 gunicorn==23.0.0
 idna==3.10
 kombu==5.4.2
-numpy==1.24.3
+numpy==1.26.4
 packaging==24.1
-pandas==2.0.3
+pandas==2.2.2
 # pandas-ta beta naming on PyPI uses 0.3.14b (no trailing 0)
 # Fallback to VCS URL to avoid PyPI resolver issues on py311 builders
 # Use release tarball to avoid git auth in builders
@@ -48,14 +48,14 @@ wcwidth==0.2.13
 whitenoise==6.7.0
 PyYAML==6.0.2
 
-fastapi==0.115.2
-uvicorn[standard]==0.30.6
-pydantic==1.10.15
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+pydantic==2.7.4
 httpx==0.27.0
 fastjsonschema==2.19.1
 
-streamlit>=1.28.0
-plotly>=5.17.0
+streamlit==1.36.0
+plotly==5.22.0
 ta>=0.11.0
 
 slowapi==0.1.8


### PR DESCRIPTION
## Summary
- Sync FastAPI, Uvicorn, Pydantic, numpy, pandas, streamlit, and plotly versions with constraint pins

## Testing
- `pip install -r requirements.txt -c constraints.txt`
- `pytest` *(fails: RuntimeError populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1ab0eb2d48328857accb37197f5b1