### PR TITLE
refactor: migrate to openai actions spec

### DIFF
--- a/openai-actions.yaml
+++ b/openai-actions.yaml
@@ -1,7 +1,9 @@
+schema_version: 1
 actions:
-  - name: actions_read
-    description: Query a read-only action via alias endpoint
-    endpoint: /api/v1/actions/read
+  - name_for_model: actions_read
+    name_for_human: "Read Action"
+    description_for_model: "Query a read-only action via alias endpoint"
+    action_url: https://mcp1.zanalytics.app/api/v1/actions/read
     method: GET
     parameters:
       type: object
@@ -41,11 +43,13 @@ actions:
           type: number
         user_id:
           type: string
-    required: [type]
-
-  - name: actions_query
-    description: Query a read-only action
-    endpoint: /api/v1/actions/query
+      required:
+        - type
+    action_status: enabled
+  - name_for_model: actions_query
+    name_for_human: "Query Action"
+    description_for_model: "Query a read-only action"
+    action_url: https://mcp1.zanalytics.app/api/v1/actions/query
     method: GET
     parameters:
       type: object
@@ -85,11 +89,13 @@ actions:
           type: number
         user_id:
           type: string
-    required: [type]
-
-  - name: actions_execute
-    description: Execute an action via the Actions Bus
-    endpoint: /api/v1/actions/query
+      required:
+        - type
+    action_status: enabled
+  - name_for_model: actions_execute
+    name_for_human: "Execute Action"
+    description_for_model: "Execute an action via the Actions Bus"
+    action_url: https://mcp1.zanalytics.app/api/v1/actions/query
     method: POST
     parameters:
       type: object
@@ -121,14 +127,17 @@ actions:
             - journal_append
             - behavior_events
             - whisper_suggest
-      payload:
-        type: object
-        additionalProperties: true
-    required: [type, payload]
-
-  - name: position_close
-    description: Close full or partial position
-    endpoint: /api/v1/positions/close
+        payload:
+          type: object
+          additionalProperties: true
+      required:
+        - type
+        - payload
+    action_status: enabled
+  - name_for_model: position_close
+    name_for_human: "Close Position"
+    description_for_model: "Close full or partial position"
+    action_url: https://mcp1.zanalytics.app/api/v1/positions/close
     method: POST
     parameters:
       type: object
@@ -144,11 +153,13 @@ actions:
         volume:
           type: number
           description: Optional absolute lots to close (overrides fraction if provided)
-      required: [ticket]
-
-  - name: position_modify
-    description: Modify SL/TP for an existing position
-    endpoint: /api/v1/positions/modify
+      required:
+        - ticket
+    action_status: enabled
+  - name_for_model: position_modify
+    name_for_human: "Modify Position"
+    description_for_model: "Modify SL/TP for an existing position"
+    action_url: https://mcp1.zanalytics.app/api/v1/positions/modify
     method: POST
     parameters:
       type: object
@@ -162,11 +173,13 @@ actions:
         tp:
           type: number
           description: New take-profit price
-      required: [ticket]
-
-  - name: position_modify_by_ticket
-    description: Modify SL/TP for an existing position by ticket path
-    endpoint: /api/v1/positions/{ticket}/modify
+      required:
+        - ticket
+    action_status: enabled
+  - name_for_model: position_modify_by_ticket
+    name_for_human: "Modify Position By Ticket"
+    description_for_model: "Modify SL/TP for an existing position by ticket path"
+    action_url: https://mcp1.zanalytics.app/api/v1/positions/{ticket}/modify
     method: POST
     parameters:
       type: object
@@ -180,11 +193,13 @@ actions:
         tp:
           type: number
           description: New take-profit price
-      required: [ticket]
-
-  - name: position_hedge
-    description: Open an opposite-side hedge order for a position
-    endpoint: /api/v1/positions/hedge
+      required:
+        - ticket
+    action_status: enabled
+  - name_for_model: position_hedge
+    name_for_human: "Hedge Position"
+    description_for_model: "Open an opposite-side hedge order for a position"
+    action_url: https://mcp1.zanalytics.app/api/v1/positions/hedge
     method: POST
     parameters:
       type: object
@@ -195,46 +210,91 @@ actions:
         volume:
           type: number
           description: Optional hedge volume (defaults to full position volume)
-      required: [ticket]
-
-  - name: trade_open
-    description: Open a new trading position
-    endpoint: /trade/open
+      required:
+        - ticket
+    action_status: enabled
+  - name_for_model: trade_open
+    name_for_human: "Open Trade"
+    description_for_model: "Open a new trading position"
+    action_url: https://mcp1.zanalytics.app/trade/open
     method: POST
     parameters:
       type: object
       properties:
-        symbol: { type: string }
-        side: { type: string, enum: [buy, sell] }
-        volume: { type: number }
-        type: { type: string, enum: [market, limit, stop], nullable: true }
-        price: { type: number, nullable: true }
-        sl: { type: number, nullable: true }
-        tp: { type: number, nullable: true }
-        deviation: { type: integer, nullable: true }
-        client_order_id: { type: string, nullable: true }
-      required: [symbol, side, volume]
-
-  - name: trade_close
-    description: Close an existing trading position
-    endpoint: /trade/close
+        symbol:
+          type: string
+        side:
+          type: string
+          enum:
+            - buy
+            - sell
+        volume:
+          type: number
+        type:
+          type: string
+          enum:
+            - market
+            - limit
+            - stop
+          nullable: true
+        price:
+          type: number
+          nullable: true
+        sl:
+          type: number
+          nullable: true
+        tp:
+          type: number
+          nullable: true
+        deviation:
+          type: integer
+          nullable: true
+        client_order_id:
+          type: string
+          nullable: true
+      required:
+        - symbol
+        - side
+        - volume
+    action_status: enabled
+  - name_for_model: trade_close
+    name_for_human: "Close Trade"
+    description_for_model: "Close an existing trading position"
+    action_url: https://mcp1.zanalytics.app/trade/close
     method: POST
     parameters:
       type: object
       properties:
-        ticket: { type: integer, description: Trade ticket ID to close }
-        volume: { type: number, nullable: true, description: Optional volume to close }
-        deviation: { type: integer, nullable: true }
-      required: [ticket]
-
-  - name: trade_modify
-    description: Modify stop-loss or take-profit for a position
-    endpoint: /trade/modify
+        ticket:
+          type: integer
+          description: Trade ticket ID to close
+        volume:
+          type: number
+          nullable: true
+          description: Optional volume to close
+        deviation:
+          type: integer
+          nullable: true
+      required:
+        - ticket
+    action_status: enabled
+  - name_for_model: trade_modify
+    name_for_human: "Modify Trade"
+    description_for_model: "Modify stop-loss or take-profit for a position"
+    action_url: https://mcp1.zanalytics.app/trade/modify
     method: POST
     parameters:
       type: object
       properties:
-        ticket: { type: integer, description: Trade ticket ID }
-        sl: { type: number, nullable: true }
-        tp: { type: number, nullable: true }
-      required: [ticket]
+        ticket:
+          type: integer
+          description: Trade ticket ID
+        sl:
+          type: number
+          nullable: true
+        tp:
+          type: number
+          nullable: true
+      required:
+        - ticket
+    action_status: enabled


### PR DESCRIPTION
## Summary
- migrate legacy actions manifest to `openai-actions.yaml` in OpenAI actions schema
- remove outdated `actions/OPENAI_ACTIONS.yaml`

## Testing
- `pytest` *(fails: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1b9b6552883289d8a60003c174c3b