### PR TITLE
Add scripts to validate and test OpenAI actions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,3 +65,14 @@ Run this:
 ```bash
 docker compose up
 ```
+
+## Action manifest checks
+
+Keep the OpenAI Actions manifest in sync with the MCP server and smoke‑test the endpoints:
+
+```bash
+python scripts/verify_actions.py
+python scripts/test_actions.py
+```
+
+More details are in [openai-actions.md](openai-actions.md).

--- a/docs/openai-actions.md
+++ b/docs/openai-actions.md
@@ -1,0 +1,31 @@
+# OpenAI Actions
+
+This project exposes a set of OpenAI Actions defined in `openai-actions.yaml`.
+The manifest lists each action name, URL and parameter schema. Two helper
+scripts ensure the manifest stays in sync with the MCP server and that endpoints
+respond as expected.
+
+## Verify action coverage
+
+Run the verification script to confirm that every `name_for_model` entry in the
+manifest has a corresponding route implemented by the MCP FastAPI server:
+
+```bash
+python scripts/verify_actions.py
+```
+
+Any missing routes are printed to STDOUT and the script exits with a non-zero
+status.
+
+## Smoke-test action endpoints
+
+`scripts/test_actions.py` performs a minimal HTTP request against each action.
+It uses placeholder values for required parameters and reports whether the
+endpoint returned a non-error status code.
+
+```bash
+python scripts/test_actions.py
+```
+
+These checks are lightweight and intended for developer workflows. They do not
+replace comprehensive testing of the underlying services.

--- a/scripts/test_actions.py
+++ b/scripts/test_actions.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Send minimal requests to each OpenAI action endpoint.
+
+Reads action definitions from ``openai-actions.yaml`` and performs a simple
+HTTP request for each one, using placeholder values for required parameters.
+The script prints a short summary showing which actions responded without
+errors. It is a lightweight smoke test and does not validate response content.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "openai-actions.yaml"
+
+
+def load_actions() -> list[dict]:
+    with MANIFEST.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("actions", [])
+
+
+def sample_value(field: dict):
+    if isinstance(field, dict):
+        if "enum" in field:
+            return field["enum"][0]
+        t = field.get("type")
+        if t == "string":
+            return ""
+        if t in {"integer", "number"}:
+            return 0
+        if t == "boolean":
+            return False
+    return None
+
+
+def build_payload(schema: dict) -> dict:
+    payload: dict = {}
+    props = schema.get("properties", {})
+    required = schema.get("required", [])
+    for name in required:
+        payload[name] = sample_value(props.get(name, {}))
+    return payload
+
+
+def main() -> int:
+    actions = load_actions()
+    client = httpx.Client(timeout=5)
+    for action in actions:
+        name = action.get("name_for_model")
+        url = action.get("action_url")
+        method = action.get("method", "GET").upper()
+        params_schema = action.get("parameters", {})
+        payload = build_payload(params_schema)
+
+        # Replace path parameters in URL
+        if url:
+            for match in re.findall(r"{(.*?)}", url):
+                replacement = payload.get(match, 1)
+                url = url.replace(f"{{{match}}}", str(replacement))
+        else:
+            print(f"{name}: missing URL")
+            continue
+
+        try:
+            if method == "GET":
+                resp = client.get(url, params=payload)
+            else:
+                resp = client.request(method, url, json=payload)
+            status = resp.status_code
+            ok = 200 <= status < 400
+            print(f"{name}: {'OK' if ok else f'HTTP {status}'}")
+        except Exception as exc:  # pragma: no cover - network errors
+            print(f"{name}: error {exc}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_actions.py
+++ b/scripts/verify_actions.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Verify that OpenAI action manifest names map to MCP server routes.
+
+The script loads ``openai-actions.yaml`` at the project root and compares the
+``name_for_model`` entries to the actual ``APIRoute.path`` values exposed by the
+FastAPI app in ``backend/mcp/mcp_server.py``. It helps catch stale manifest
+entries that no longer have a corresponding server implementation.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+from fastapi.routing import APIRoute
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "openai-actions.yaml"
+
+
+def load_manifest() -> dict:
+    """Load action definitions from ``openai-actions.yaml``."""
+    with MANIFEST.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data or {}
+
+
+def get_manifest_paths() -> dict[str, str]:
+    """Return mapping of action ``name_for_model`` -> path."""
+    data = load_manifest()
+    actions = data.get("actions", [])
+    mapping: dict[str, str] = {}
+    for action in actions:
+        name = action.get("name_for_model")
+        url = action.get("action_url", "")
+        path = urlparse(url).path
+        if name:
+            mapping[name] = path
+    return mapping
+
+
+def get_server_paths() -> set[str]:
+    """Return set of paths served by the MCP FastAPI app."""
+    sys.path.insert(0, str(ROOT / "backend" / "mcp"))
+    try:
+        from mcp_server import app  # type: ignore
+    except Exception as exc:  # pragma: no cover - import failure reported
+        print(f"Failed to import mcp_server: {exc}")
+        return set()
+
+    return {
+        route.path
+        for route in app.routes
+        if isinstance(route, APIRoute)
+    }
+
+
+def main() -> int:
+    manifest = get_manifest_paths()
+    server_paths = get_server_paths()
+
+    missing = {name: path for name, path in manifest.items() if path not in server_paths}
+
+    if missing:
+        print("Missing routes for actions:")
+        for name, path in sorted(missing.items()):
+            print(f"  {name}: {path}")
+        return 1
+
+    print("All manifest actions have matching server routes.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `verify_actions.py` to check `openai-actions.yaml` against MCP routes
- add `test_actions.py` for basic action smoke tests
- document OpenAI action tooling and reference scripts in onboarding

## Testing
- `python scripts/verify_actions.py`
- `python scripts/test_actions.py`
- `pytest` *(fails: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1bcf8af2c8328bdb55e8ae0a9e2ce