### PR TITLE
refactor: unify action post endpoints

### DIFF
--- a/backend/mcp/mcp_server.py
+++ b/backend/mcp/mcp_server.py
@@ -190,12 +190,10 @@ async def get_actions_read(
 
 
 @app.post("/api/v1/actions/read")
-
-async def post_actions_read(payload: ActionPayload):
+async def post_actions_read(payload: ActionPayload | dict):
+    if isinstance(payload, dict):
+        payload = ActionPayload.model_validate(payload)
     return await _handle_read_action(payload.type)
-
-async def post_actions_read(payload: dict):
-    return await _handle_read_action(payload.get("type", "session_boot"))
 
 @app.get("/api/v1/actions/query")
 async def get_actions_query(
@@ -213,12 +211,10 @@ async def get_actions_query(
 
 
 @app.post("/api/v1/actions/query")
-
-async def post_actions_query(payload: ActionPayload):
+async def post_actions_query(payload: ActionPayload | dict):
+    if isinstance(payload, dict):
+        payload = ActionPayload.model_validate(payload)
     return await _handle_read_action(payload.type)
-
-async def post_actions_query(payload: dict):
-    return await _handle_read_action(payload.get("type", "session_boot"))
 
 
 


### PR DESCRIPTION
## Summary
- consolidate duplicate post actions handlers
- validate dict payloads against ActionPayload

## Testing
- `pytest backend/mcp`

------
https://chatgpt.com/codex/tasks/task_b_68c1c1081c5c83289b15079c717c4f3a