### PR TITLE
Add MT5 order normalization in MCP server

### DIFF
--- a/backend/mcp/mcp_server.py
+++ b/backend/mcp/mcp_server.py
@@ -6,6 +6,12 @@ import asyncio
 import httpx
 import os
 import time
+import pandas as pd
+from utils.time import localize_tz
+try:  # pragma: no cover - optional dependency
+    import MetaTrader5 as mt5  # type: ignore
+except Exception:  # pragma: no cover - allow module to import without MT5
+    mt5 = None
 from prometheus_client import (
     Counter,
     Gauge,
@@ -215,10 +221,22 @@ async def get_actions_query(
 @app.post("/api/v1/actions/query")
 
 async def post_actions_query(payload: ActionPayload):
-    return await _handle_read_action(payload.type)
+    def normalize_mt5_orders(orders):
+        df = pd.DataFrame([vars(o) for o in orders])
+        if "time_setup" in df.columns:
+            df["time_setup"] = pd.to_datetime(df["time_setup"], unit="s", utc=True)
+            df["time_setup"] = df["time_setup"].apply(localize_tz)
+        df = df[["ticket", "symbol", "type", "volume", "price_open", "time_setup"]]
+        return df.rename(columns={"price_open": "entry", "type": "side"})
 
-async def post_actions_query(payload: dict):
-    return await _handle_read_action(payload.get("type", "session_boot"))
+    if mt5 is None:  # pragma: no cover - dependency guard
+        return []
+
+    orders = mt5.orders_get(limit=10)
+    if orders is None:
+        return []
+    df = normalize_mt5_orders(orders)
+    return df.to_dict("records")
 
 
 

--- a/utils/time.py
+++ b/utils/time.py
@@ -1,0 +1,25 @@
+import os
+from typing import Union
+import pandas as pd
+
+LOCAL_TZ = os.getenv("TZ", "UTC")
+
+def localize_tz(ts: Union[pd.Timestamp, int, float, str]) -> pd.Timestamp:
+    """Convert a UTC timestamp to the local timezone.
+
+    Parameters
+    ----------
+    ts: Union[pd.Timestamp, int, float, str]
+        Timestamp or value convertible to :class:`pandas.Timestamp`.
+
+    Returns
+    -------
+    pd.Timestamp
+        Timezone-aware timestamp converted to ``TZ`` environment setting
+        (defaults to UTC).
+    """
+    if not isinstance(ts, pd.Timestamp):
+        ts = pd.to_datetime(ts, utc=True)
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    return ts.tz_convert(LOCAL_TZ)


### PR DESCRIPTION
## Summary
- Normalize MT5 orders in `/api/v1/actions/query` handler
- Provide timezone localization utility

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c1c0f97fbc832892eea70cf950805f