### PR TITLE
Add timezone localization utility

### DIFF
--- a/backend/django/pulse_api/situation_builder.py
+++ b/backend/django/pulse_api/situation_builder.py
@@ -1,14 +1,13 @@
-from datetime import datetime
 import os
 import requests
 import pandas as pd
-from zoneinfo import ZoneInfo
+from utils.time import localize_tz
 
 MT5_URL = os.getenv("MT5_URL", "http://mt5:5001")
 
 
 def _now_ctx():
-    ny = datetime.now(ZoneInfo("America/New_York"))
+    ny = localize_tz(pd.Timestamp.utcnow())
     session = "LONDON" if 7 <= ny.hour <= 13 else "OTHER"
     return {
         "session": session,
@@ -53,7 +52,7 @@ def build_situation(symbol: str):
 
     return {
         "asset": symbol,
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": localize_tz(pd.Timestamp.utcnow()).isoformat(),
         "time_context": _now_ctx(),
         "macro_context": {},
         "price_data": {"symbol": symbol, "Close": price} if price is not None else {},

--- a/utils/time.py
+++ b/utils/time.py
@@ -1,0 +1,8 @@
+"""Time utilities."""
+
+import pandas as pd
+
+
+def localize_tz(ts: pd.Timestamp) -> pd.Timestamp:
+    """Convert a naive/UTC timestamp to America/New_York timezone."""
+    return ts.tz_localize("UTC").tz_convert("America/New_York")


### PR DESCRIPTION
## Summary
- add `utils.time` module with `localize_tz` for UTC to New York conversion
- use new `localize_tz` in `situation_builder` to normalize time context and timestamps

## Testing
- `pytest` *(fails: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1c1a961448328a864a60ebc82d4a9