### PR TITLE
Add MetaTrader5 initialization helper

### DIFF
--- a/backend/mcp/mt5_adapter.py
+++ b/backend/mcp/mt5_adapter.py
@@ -1,0 +1,14 @@
+import time
+import MetaTrader5 as mt5
+
+
+def init_mt5():
+    """Initialize connection to MetaTrader5 with retries."""
+    if not mt5.initialize():
+        print("MT5 not ready - retrying...")
+        time.sleep(5)
+        return init_mt5()
+    print("MT5 bridged.")
+
+
+__all__ = ["init_mt5"]


### PR DESCRIPTION
## Summary
- add `mt5_adapter` with recursive retrying `init_mt5` function for MetaTrader5 bridging

## Testing
- `pytest` *(fails: RuntimeError populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1c6444d94832880ba95865a96d5ea