### PR TITLE
docs: update Actions Bus examples

### DIFF
--- a/docs/api-security.md
+++ b/docs/api-security.md
@@ -9,15 +9,22 @@
 ## Public vs. protected endpoints
 
 - `/mcp` is a public heartbeat endpoint and requires no authentication.
-- Other routes, like `/api/v1/actions/read` or `/exec/...`, must include the `X-API-Key` header.
+- Other routes, like `POST /api/v1/actions/query` or `/exec/...`, must include the `X-API-Key` header.
 
 ## Curl example
 
 ```bash
-curl -s -H "X-API-Key: dev-key-123" http://localhost:8080/api/v1/actions/read
+curl -sX POST http://localhost:8080/api/v1/actions/query \
+  -H "X-API-Key: dev-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"session_boot","payload":{"user_id":"demo"}}'
 # Omitting the header returns 401 Unauthorized
-curl -s http://localhost:8080/api/v1/actions/read
+curl -sX POST http://localhost:8080/api/v1/actions/query \
+  -H "Content-Type: application/json" \
+  -d '{"type":"session_boot","payload":{"user_id":"demo"}}'
 ```
+
+The `Content-Type: application/json` header is required when sending JSON bodies.
 
 See [auth](auth.md) for additional authentication examples and key rotation steps.
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -7,9 +7,13 @@ All HTTP requests to the MCP server must include the `X-API-Key` header, except 
 Use a development key such as `dev-key-123` during local testing:
 
 ```bash
-curl -s -H "X-API-Key: dev-key-123" \
-  http://localhost:8080/api/v1/actions/read
+curl -sX POST "http://localhost:8080/api/v1/actions/query" \
+  -H "X-API-Key: dev-key-123" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"session_boot","payload":{"user_id":"demo"}}'
 ```
+
+The `Content-Type: application/json` header is required when sending JSON to the Actions Bus.
 
 ## Rotating the key
 

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1622,19 +1622,18 @@ Combined state snapshot for dashboards.
 
 **Sample payload**: _None_
 
-### `GET /api/v1/actions/query`
-Query consolidated actions.
+### `POST /api/v1/actions/query`
+Query consolidated actions via the Actions Bus.
 
-**Payload schema**: _None_
+**Required headers**: `Content-Type: application/json`
 
-**Sample payload**: _None_
-
-### `GET /api/v1/actions/read`
-Read-only alias of `/api/v1/actions/query`.
-
-**Payload schema**: _None_
-
-**Sample payload**: _None_
+**Sample payload**
+```json
+{
+  "type": "session_boot",
+  "payload": {"user_id": "demo"}
+}
+```
 
 ### `POST /api/v1/actions/mutate`
 Mutate via actions bus.
@@ -1726,20 +1725,15 @@ Return a snapshot of current system state.
 { "state": {} }
 ```
 
-### `GET /api/v1/actions/query`
-Read-only query of available actions.
+### `POST /api/v1/actions/query`
+Query available actions via the Actions Bus.
 
-**Sample payload**: _None_
+**Required headers**: `Content-Type: application/json`
 
-**Expected response**
+**Sample payload**
 ```json
-{ "actions": [] }
+{ "type": "session_boot", "payload": {"user_id": "demo"} }
 ```
-
-### `GET /api/v1/actions/read`
-Alias of `/api/v1/actions/query` for GET-only environments.
-
-**Sample payload**: _None_
 
 **Expected response**
 ```json

--- a/docs/openai-actions.md
+++ b/docs/openai-actions.md
@@ -9,9 +9,15 @@ and [scripts/test_actions.py](../scripts/test_actions.py) for simple tooling.
 ## Endpoints
 
 ### `POST /api/v1/actions/query`
-Execute an action via the Actions Bus.
+Execute any action via the Actions Bus. Include the `Content-Type: application/json` header.
 
-**Sample request**
+```bash
+curl -sX POST "http://localhost:8080/api/v1/actions/query" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"session_boot","payload":{"user_id":"demo"}}'
+```
+
+**Sample payload**
 
 ```json
 {
@@ -20,28 +26,7 @@ Execute an action via the Actions Bus.
 }
 ```
 
-### `GET /api/v1/actions/query`
-Fetch read-only data using query parameters.
-
-**Sample request**
-
-```json
-{
-  "type": "trades_recent",
-  "limit": 5
-}
-```
-
-### `GET /api/v1/actions/read`
-Alias of the query endpoint for read-only environments.
-
-**Sample request**
-
-```json
-{
-  "type": "account_info"
-}
-```
+`POST /api/v1/actions/query` handles both read‑only and mutating verbs; separate `GET` aliases are no longer required.
 
 ## Supported action types
 


### PR DESCRIPTION
## Summary
- standardize docs on `POST /api/v1/actions/query`
- add JSON sample payloads and note required `Content-Type: application/json`
- clarify auth and security examples for the Actions Bus

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c1c729ff5483288a098123fdd1246c