### PR TITLE
docs: update auth endpoint example

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -8,7 +8,16 @@ Use a development key such as `dev-key-123` during local testing:
 
 ```bash
 curl -s -H "X-API-Key: dev-key-123" \
-  http://localhost:8080/api/v1/actions/read
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d '{ "type": "session_boot", "payload": {} }' \
+  http://localhost:8080/api/v1/actions/query
+```
+
+Minimal JSON body:
+
+```json
+{ "type": "session_boot", "payload": {} }
 ```
 
 ## Rotating the key


### PR DESCRIPTION
## Summary
- replace `GET /api/v1/actions/read` with `POST /api/v1/actions/query`
- document minimal JSON body for actions queries

## Testing
- `pytest tests/test_mcp_auth.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c1c72676b4832899f8c2d11f21b9db