### PR TITLE
docs: remove actions mutate endpoint

### DIFF
--- a/_schema/GPT_Instructions_1.1.md
+++ b/_schema/GPT_Instructions_1.1.md
@@ -189,9 +189,8 @@ Notes:
 - Some endpoints exist but are intentionally omitted from OpenAPI to keep the 30‑action cap; use them only when instructed.
 
 ### Actions Bus (Prototype)
-- Consolidates many logical ops under two endpoints (keeps path count low):
+- Consolidates many logical ops under a single endpoint:
   - `POST /api/v1/actions/query` with `{ type, payload }` → e.g., `trades_recent`, `behavior_events`, `equity_today`, `pulse_status`.
-  - `POST /api/v1/actions/mutate` with `{ type, payload }` → e.g., `note_create`.
 - Prefer documented endpoints when building UIs; use the bus when action count is constrained.
 
 ## Remember

--- a/backend/django/app/nexus/urls.py
+++ b/backend/django/app/nexus/urls.py
@@ -46,7 +46,6 @@ from .views import (
     EquityTodayView,
     TradesRecentView,
     ActionsQueryView,
-    ActionsMutateView,
     ActionsSpecView,
     PingView,
     JournalEntryPostView,
@@ -182,7 +181,6 @@ urlpatterns = [
     path('actions/query', ActionsQueryView.as_view(), name='actions-query'),
     # Read-only alias to avoid runtime consent prompts for GET
     path('actions/read', ActionsQueryView.as_view(), name='actions-read'),
-    path('actions/mutate', ActionsMutateView.as_view(), name='actions-mutate'),
     # Serve slim OpenAPI for Actions
     path('openapi.actions.yaml', ActionsSpecView.as_view(), name='actions-openapi-spec'),
 ]

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1636,43 +1636,6 @@ Read-only alias of `/api/v1/actions/query`.
 
 **Sample payload**: _None_
 
-### `POST /api/v1/actions/mutate`
-Mutate via actions bus.
-
-**Payload schema**
-```json
-{
-  "type": "string",
-  "payload": {}
-}
-```
-
-**Sample payload**
-```json
-{
-  "type": "note_create",
-  "payload": {"text": "hi"}
-}
-```
-
-### `GET /api/v1/openapi.actions.yaml`
-Serve OpenAPI specification for Actions.
-
-**Payload schema**: _None_
-
-**Sample payload**: _None_
-
-
-**Sample payload**
-```json
-{ "symbol": "EURUSD" }
-```
-
-**Expected response**
-```json
-{ "ok": true }
-```
-
 ### `GET /api/v1/liquidity/map`
 Return a liquidity map snapshot.
 
@@ -1744,19 +1707,6 @@ Alias of `/api/v1/actions/query` for GET-only environments.
 **Expected response**
 ```json
 { "actions": [] }
-```
-
-### `POST /api/v1/actions/mutate`
-Execute a writable action.
-
-**Sample payload**
-```json
-{ "action": "close_all" }
-```
-
-**Expected response**
-```json
-{ "ok": true }
 ```
 
 ### `GET /api/v1/openapi.actions.yaml`


### PR DESCRIPTION
## Summary
- document Actions Bus as a single POST /api/v1/actions/query endpoint
- drop actions/mutate route from Django URLs and endpoint list

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus'; RuntimeError: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1c72f4cc48328994896e204a62749