### PR TITLE
Remove legacy GET endpoints for actions

### DIFF
--- a/backend/mcp/mcp_server.py
+++ b/backend/mcp/mcp_server.py
@@ -191,65 +191,11 @@ async def _handle_read_action(action_type: str):
     return {"error": "unsupported type"}
 
 
-@app.get("/api/v1/actions/read")
-async def get_actions_read(
-    type: str = "session_boot",
-    limit: int | None = None,
-    symbol: str | None = None,
-    timeframe: str | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
-    pnl_min: float | None = None,
-    pnl_max: float | None = None,
-    user_id: str | None = None,
-):
-    payload = {
-        "type": type,
-        "limit": limit,
-        "symbol": symbol,
-        "timeframe": timeframe,
-        "date_from": date_from,
-        "date_to": date_to,
-        "pnl_min": pnl_min,
-        "pnl_max": pnl_max,
-        "user_id": user_id,
-    }
-    return await post_actions_query(payload)
-
-
 @app.post("/api/v1/actions/read")
 async def post_actions_read(payload: ActionPayload | dict):
     return await post_actions_query(payload)
 
-@app.get("/api/v1/actions/query")
-async def get_actions_query(
-    type: str = "session_boot",
-    limit: int | None = None,
-    symbol: str | None = None,
-    timeframe: str | None = None,
-    date_from: str | None = None,
-    date_to: str | None = None,
-    pnl_min: float | None = None,
-    pnl_max: float | None = None,
-    user_id: str | None = None,
-):
-    payload = {
-        "type": type,
-        "limit": limit,
-        "symbol": symbol,
-        "timeframe": timeframe,
-        "date_from": date_from,
-        "date_to": date_to,
-        "pnl_min": pnl_min,
-        "pnl_max": pnl_max,
-        "user_id": user_id,
-    }
-    return await post_actions_query(payload)
-
-
 @app.post("/api/v1/actions/query")
-
-
 async def post_actions_query(payload: ActionPayload):
     def normalize_mt5_orders(orders):
         df = pd.DataFrame([vars(o) for o in orders])

--- a/openai-actions.yaml
+++ b/openai-actions.yaml
@@ -1,8 +1,6 @@
 schema_version: 1
 actions:
   - name_for_model: actions_query
-    name_for_human: "Execute Action"
-    description_for_model: "Execute an action via the Actions Bus"
     name_for_human: "Query Action"
     description_for_model: "Query or execute an action via the Actions Bus"
     action_url: https://mcp1.zanalytics.app/api/v1/actions/query


### PR DESCRIPTION
## Summary
- drop GET `/api/v1/actions/read` and `/api/v1/actions/query` from MCP server
- streamline manifest to only expose POST `actions_query`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68c1c950b8b4832891ab56e0aab3195c