### PR TITLE
Refine live status error handling

### DIFF
--- a/LLM/Whisper Ack-Act UI Additions.py
+++ b/LLM/Whisper Ack-Act UI Additions.py
@@ -32,7 +32,7 @@ def display_live_status():
         else:
             st.warning("⚠️ Awaiting feed (fallback to local breadcrumb)")
     except requests.RequestException as exc:
-        logging.exception("Error checking live data status")
+        logging.exception("Error checking live data status: %s", exc)
         st.error("❌ API unreachable - check base override")
 
 # Shared Helper: Render Whisper with Ack/Act Buttons


### PR DESCRIPTION
## Summary
- handle only `requests.RequestException` in `display_live_status`
- log request failure details before showing streamlit error

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c1c97d3710832894d7e5002ab433a5