### PR TITLE
docs: expand troubleshooting and FAQs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -90,5 +90,38 @@ A:
 3. Rebuild and start fresh containers: `docker-compose up --build`.
 4. Rerun database migrations if applicable.
 
+**Q: Traefik route isn't matching my service?**
+A: Router labels may be off. Check `traefik.http.routers` rules in [`docker-compose.yml`](../docker-compose.yml) and match `Host`/`PathPrefix` to the request. See [troubleshooting](troubleshooting.md#traefik-routing-labels).
+
+**Q: On macOS, commands fail with a locked keychain?**
+A: Unlock it before running Docker or git:
+```bash
+security unlock-keychain login.keychain-db
+```
+Then retry the command. More tips in [troubleshooting](troubleshooting.md#macos-keychain-unlock).
+
+**Q: How do I clean up ghost containers?**
+A: Remove stragglers and rebuild:
+```bash
+docker compose down -v
+docker container prune -f
+docker compose up --build
+```
+See [troubleshooting](troubleshooting.md#ghost-container-cleanup) for details.
+
+**Q: MT5 quotes look stale—how do I refresh the feed?**
+A: Restart the [mt5_gateway](../mt5_gateway/README.md) container:
+```bash
+docker compose restart mt5
+```
+Verify ticks with `curl "$MT5_API_URL/ticks?symbol=EURUSD&limit=1"`.
+
+**Q: Which header carries the API key?**
+A: Use `X-API-Key` with the value from `$MCP_API_KEY`:
+```bash
+curl -H "X-API-Key: $MCP_API_KEY" http://localhost:8001/api/...
+```
+See [api-security.md](api-security.md) for rotation guidance.
+
 **Q: Why does Whisperer still ask for approval after sending `approve: true`?**
-A: Cached action state. In the OpenAI builder, delete and re-add the MCP connector, or include `force: true` in the payload to bypass cache.
+A: Cached action state. Delete and re-add the MCP connector in the OpenAI builder, or include `force: true` with `approve: true` to bypass cache. See [WHISPERER.md](WHISPERER.md) for payload examples.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,3 +22,41 @@
 - **Out-of-date images** – run `docker compose pull` to update tags.
 - **Volume permission errors** – check host directory ownership.
 - **Compose plugin/version mismatch** – confirm `docker compose version` ≥ 2.
+
+## Traefik Routing Labels
+- Ensure labels like `traefik.enable` and `traefik.http.routers.*.rule` match the request in [`docker-compose.yml`](../docker-compose.yml).
+- Adjust `Host`/`PathPrefix` rules for each service and reload with `docker compose restart traefik`.
+
+## macOS Keychain Unlock
+- Unlock the macOS keychain if Docker or `git` prompts stall:
+  ```bash
+  security unlock-keychain login.keychain-db
+  ```
+- Re-run the original command after unlocking.
+
+## Ghost Container Cleanup
+- List stragglers: `docker ps -a`.
+- Remove stale containers and volumes:
+  ```bash
+  docker compose down -v
+  docker container prune -f
+  ```
+- Rebuild the stack with `docker compose up --build`.
+
+## Whisperer Approval Flag
+- Cached actions may ignore `approve: true`.
+- Include `force: true` or delete/re-add the connector in the OpenAI builder.
+- See [WHISPERER.md](WHISPERER.md) for payload examples.
+
+## Stale MT5 Feeds
+- Check the [mt5_gateway](../mt5_gateway/README.md) logs: `docker compose logs mt5`.
+- Restart the feed: `docker compose restart mt5`.
+- Validate ticks with `curl "$MT5_API_URL/ticks?symbol=EURUSD&limit=1"`.
+
+## API Key Header Usage
+- Protected endpoints require `X-API-Key` headers.
+- Example:
+  ```bash
+  curl -H "X-API-Key: $MCP_API_KEY" http://localhost:8001/api/...
+  ```
+- See [api-security.md](api-security.md) for rotation and storage details.


### PR DESCRIPTION
## Summary
- add troubleshooting sections for Traefik labels, macOS keychain unlock, ghost container cleanup, Whisperer approval flag, stale MT5 feeds, and API key header usage
- extend FAQ with matching entries and cross-links to services and docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError, RuntimeError: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1cd4bcdf4832887f1810572ee73d0