### PR TITLE
Add MCP1 authenticate action to manifest

### DIFF
--- a/openai-actions.yaml
+++ b/openai-actions.yaml
@@ -206,3 +206,17 @@ actions:
       required:
         - ticket
     action_status: enabled
+  - name_for_model: mcp1_authenticate
+    name_for_human: "Authenticate Session"
+    description_for_model: "Validate MCP1 auth token"
+    action_url: https://mcp1.zanalytics.app/api/v1/mcp1/authenticate
+    method: POST
+    parameters:
+      type: object
+      properties:
+        token:
+          type: string
+          description: Session token to validate
+      required:
+        - token
+    action_status: enabled


### PR DESCRIPTION
## Summary
- add mcp1_authenticate action to openai manifest to match spec

## Testing
- `python scripts/verify_actions.py` (fails to import mcp_server but spec routes now present in manifest)


------
https://chatgpt.com/codex/tasks/task_b_68c1d9cea4508328855a149a012d4ff2