### PR TITLE
Mount shared .env for mcp service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -678,6 +678,8 @@ services:
     build:
       context: ./backend/mcp
     container_name: mcp
+    volumes:
+      - ./.env:/app/.env
     ports:
     - 8001:8001
     environment:


### PR DESCRIPTION
## Summary
- Mount root `.env` into the `mcp` service

## Testing
- `pytest` *(fails: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1e1afef6c8328aae2cf2ec4a7b7db