### PR TITLE
chore: document httpx client context manager

### DIFF
--- a/scripts/test_actions.py
+++ b/scripts/test_actions.py
@@ -50,6 +50,7 @@ def build_payload(schema: dict) -> dict:
 
 def main() -> int:
     actions = load_actions()
+    # Use a context manager so the client is closed even if a request fails
     with httpx.Client(timeout=5) as client:
         for action in actions:
             name = action.get("name_for_model")


### PR DESCRIPTION
## Summary
- document use of context manager for httpx client in test script to guarantee proper closing on errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c1e196d1ac8328ae82f3efe9c9ca36