### PR TITLE
docs: link active docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,14 +22,14 @@ points to the current sources of truth and clearly marks legacy docs.
 Current Direction (Active)
 --------------------------
 
-- Architecture (streaming): docs/architecture_pulse_streaming.md
-- Journal envelopes and contracts: docs/journal_envelopes.md
-- Actions API overview: docs/ACTIONS_API_OVERVIEW.md
-- Kafka sidecar quickstart: ops/kafka/quickstart.md
-- Pulse runtime (gates + detail API): backend/django/app/nexus/pulse/README.md
-- Services (mirror, tick→bar, reconciler): services/README.md
-- Dashboard pages index: dashboard/pages/README.md
-- Monitoring stack: docs/monitoring.md
+- [Architecture (streaming)](architecture_pulse_streaming.md)
+- [Journal envelopes and contracts](journal_envelopes.md)
+- [Actions API overview](ACTIONS_API_OVERVIEW.md)
+- [Kafka sidecar quickstart](../ops/kafka/quickstart.md)
+- [Pulse runtime (gates + detail API)](../backend/django/app/nexus/pulse/README.md)
+- [Services (mirror, tick→bar, reconciler)](../services/README.md)
+- [Dashboard pages index](../dashboard/pages/README.md)
+- [Monitoring stack](monitoring.md)
 
 Legacy / Retired (kept for history)
 -----------------------------------


### PR DESCRIPTION
## Summary
- convert doc references in active section to Markdown links

## Testing
- `python -m markdown docs/README.md | sed -n '20,40p'`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c1e4fda078832889b45679a8d2af4c