### PR TITLE
Remove duplicate README ToC entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,8 @@ For deeper architecture insights and API details, visit the [docs README](docs/R
 - [Known Issues & Best Practices](#known-issues-best-practices)
 - [Future Directions & Next Steps](#future-directions-next-steps)
 
-- [License (Strict, Non-Transferable)](#license-strict-non-transferable)
-- [Advanced Usage](#advanced-usage)
-
 - [License](#license)
-- [Advanced Usage: Adding a New Dashboard](#advanced-usage-adding-a-new-dashboard)
+- [Advanced Usage](#advanced-usage)
 
 - [Full API Documentation](#full-api-documentation)
 - [FAQ](#faq)


### PR DESCRIPTION
## Summary
- remove redundant License and Advanced Usage listings from Table of Contents in README

## Testing
- `pytest` *(fails: RuntimeError: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1e6427c6883289fd29c9741ceb9e9