### PR TITLE
docs: standardize docker compose usage

### DIFF
--- a/PULSE_WYCKOFF_LIVE_README.md
+++ b/PULSE_WYCKOFF_LIVE_README.md
@@ -70,7 +70,7 @@ REDIS_PORT = 6379
 #### Start Services
 ```bash
 # Start all required services
-docker-compose up -d mt5 redis django streamlit
+docker compose up -d mt5 redis django streamlit
 ```
 
 #### Access Dashboard
@@ -118,7 +118,7 @@ Update the `phase_colors` in the config or modify the `create_wyckoff_chart()` f
 
 ### No Data Displayed
 - Check MT5 terminal is running
-- Verify API services are up: `docker-compose ps`
+- Verify API services are up: `docker compose ps`
 - Ensure market is open for selected symbol
 
 ### Slow Performance
@@ -129,7 +129,7 @@ Update the `phase_colors` in the config or modify the `create_wyckoff_chart()` f
 ### Connection Errors
 - Check firewall settings
 - Verify Docker network configuration
-- Review API logs: `docker-compose logs mt5`
+- Review API logs: `docker compose logs mt5`
 
 ## Performance Metrics
 

--- a/README.md
+++ b/README.md
@@ -97,15 +97,15 @@ Before starting, install the core tooling: [Git](https://git-scm.com/book/en/v2/
 3. **Build and start the platform:**
     ```bash
     docker network create traefik-public
-    docker-compose build --no-cache
-    docker-compose up -d
+    docker compose build --no-cache
+    docker compose up -d
     ```
 
 4. **Check all services:**
     ```bash
-    docker-compose ps
-    docker-compose logs dashboard
-    docker-compose logs mt5
+    docker compose ps
+    docker compose logs dashboard
+    docker compose logs mt5
     ```
 
 5. **Access the dashboards and APIs:**
@@ -267,7 +267,7 @@ Add new Streamlit dashboards following [docs/advanced_dashboard.md](docs/advance
 Common setup and operational questions live in [docs/faq.md](docs/faq.md).
 
 **Q: Something isn’t working—how do I see detailed error logs?**
-A: Use `docker-compose logs <service>` (add `-f` to follow in real time) or `docker logs <container>` for single containers. For service-specific errors, check Django's debug logs and MT5 bridge logs.
+A: Use `docker compose logs <service>` (add `-f` to follow in real time) or `docker logs <container>` for single containers. For service-specific errors, check Django's debug logs and MT5 bridge logs.
 
 **Q: Can I run this without Docker?**
 A: Not recommended. The MT5 and dashboard stack is designed for containerization for full reproducibility and security.
@@ -296,7 +296,7 @@ A: MetaTrader likely didn’t boot—ensure Wine and required DLLs are available
 A:
 1. Run the following to flush all cached keys:
    ```bash
-   docker-compose exec redis redis-cli FLUSHALL
+   docker compose exec redis redis-cli FLUSHALL
    ```
 2. Restart the services so caches repopulate with fresh data.
 
@@ -304,26 +304,26 @@ A:
 A:
 1. Stop the services:
    ```bash
-   docker-compose down
+   docker compose down
    ```
 2. Remove the Postgres volume (be sure you're ok losing all data):
    ```bash
-   docker volume rm <name>  # or docker-compose down -v
+   docker volume rm <name>  # or docker compose down -v
    ```
 3. Rerun migrations to recreate schema:
    ```bash
-   docker-compose run django migrate
+   docker compose run django migrate
    ```
 4. Restart the stack:
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 
 **Q: Docker containers fail to build/start.**
 A:
 1. Verify your Docker installation and version.
-2. Rebuild images without cache using `docker-compose build --no-cache`.
-3. Check container output with `docker-compose logs`.
+2. Rebuild images without cache using `docker compose build --no-cache`.
+3. Check container output with `docker compose logs`.
 4. Ensure required ports are free to avoid conflicts.
 
 **Q: Docker containers complain about file or directory permissions.**
@@ -371,9 +371,9 @@ A:
 
 **Q: How do I reset the containers when data gets corrupted or outdated?**
 A:
-1. Stop and remove containers and volumes: `docker-compose down -v`.
+1. Stop and remove containers and volumes: `docker compose down -v`.
 2. Remove any orphan containers: `docker container prune -f`.
-3. Rebuild and start fresh containers: `docker-compose up --build`.
+3. Rebuild and start fresh containers: `docker compose up --build`.
 4. Rerun database migrations if applicable.
 
 

--- a/dashboard/RISK_DASHBOARD_SETUP.md
+++ b/dashboard/RISK_DASHBOARD_SETUP.md
@@ -33,14 +33,14 @@ python-dotenv==1.0.0
 
 Install in your Docker container:
 ```bash
-docker-compose exec django pip install MetaTrader5 plotly redis python-dotenv
+docker compose exec django pip install MetaTrader5 plotly redis python-dotenv
 ```
 
 ## 4. Access the Dashboard
 
 1. Start your services:
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 2. Access Streamlit:
@@ -112,11 +112,11 @@ python 16_risk_manager_mock.py
 - Ensure MetaTrader5 package is installed
 
 ### Redis Connection Issues
-- Verify Redis is running: `docker-compose ps redis`
-- Check Redis connectivity: `docker-compose exec redis redis-cli ping`
+- Verify Redis is running: `docker compose ps redis`
+- Check Redis connectivity: `docker compose exec redis redis-cli ping`
 
 ### Dashboard Not Loading
-- Check Streamlit logs: `docker-compose logs streamlit`
+- Check Streamlit logs: `docker compose logs streamlit`
 - Verify file permissions
 - Ensure all dependencies are installed
 

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -9,7 +9,7 @@
 - Pulse Kernel (FastAPI, optional) — `services/pulse_api/main.py`
 - Dashboard (Streamlit) — depends on Django health
 
-## docker-compose
+## docker compose
 
 - Ensure `DJANGO_SECRET_KEY` only set once with default fallback
 - Celery/Celery Beat:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,7 +1,7 @@
 # FAQ
 
 **Q: Something isn’t working—how do I see detailed error logs?**
-A: Use `docker-compose logs <service>` (add `-f` to follow in real time) or `docker logs <container>` for single containers. For service-specific errors, check Django's debug logs and MT5 bridge logs.
+A: Use `docker compose logs <service>` (add `-f` to follow in real time) or `docker logs <container>` for single containers. For service-specific errors, check Django's debug logs and MT5 bridge logs.
 
 **Q: Can I run this without Docker?**
 A: Not recommended. The MT5 and dashboard stack is designed for containerization for full reproducibility and security.
@@ -25,7 +25,7 @@ A: Confirm your `.env` credentials, ensure the services are running (`docker ps`
 A:
 1. Run the following to flush all cached keys:
    ```bash
-   docker-compose exec redis redis-cli FLUSHALL
+   docker compose exec redis redis-cli FLUSHALL
    ```
 2. Restart the services so caches repopulate with fresh data.
 
@@ -33,26 +33,26 @@ A:
 A:
 1. Stop the services:
    ```bash
-   docker-compose down
+   docker compose down
    ```
 2. Remove the Postgres volume (be sure you're ok losing all data):
    ```bash
-   docker volume rm <name>  # or docker-compose down -v
+   docker volume rm <name>  # or docker compose down -v
    ```
 3. Rerun migrations to recreate schema:
    ```bash
-   docker-compose run django migrate
+   docker compose run django migrate
    ```
 4. Restart the stack:
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 
 **Q: Docker containers fail to build/start.**
 A:
 1. Verify your Docker installation and version.
-2. Rebuild images without cache using `docker-compose build --no-cache`.
-3. Check container output with `docker-compose logs`.
+2. Rebuild images without cache using `docker compose build --no-cache`.
+3. Check container output with `docker compose logs`.
 4. Ensure required ports are free to avoid conflicts.
 
 **Q: Docker containers complain about file or directory permissions.**
@@ -85,9 +85,9 @@ A:
 
 **Q: How do I reset the containers when data gets corrupted or outdated?**
 A:
-1. Stop and remove containers and volumes: `docker-compose down -v`.
+1. Stop and remove containers and volumes: `docker compose down -v`.
 2. Remove any orphan containers: `docker container prune -f`.
-3. Rebuild and start fresh containers: `docker-compose up --build`.
+3. Rebuild and start fresh containers: `docker compose up --build`.
 4. Rerun database migrations if applicable.
 
 **Q: Traefik route isn't matching my service?**

--- a/docs/full-setup-guide.md
+++ b/docs/full-setup-guide.md
@@ -58,8 +58,8 @@ docker network create traefik-public
 From the repository root, build and launch all services:
 
 ```bash
-docker-compose build --no-cache
-docker-compose up -d
+docker compose build --no-cache
+docker compose up -d
 ```
 
 ## 7. Verify the services

--- a/docs/info-site.md
+++ b/docs/info-site.md
@@ -12,7 +12,7 @@ The public info site mirrors content from this repository's `docs/` folder.
 
 - A lightweight Streamlit app renders the Markdown files.
 - You can also generate a static site with tools like MkDocs.
-- Example `docker-compose` snippet:
+- Example `docker compose` snippet:
   ```yaml
   volumes:
     - ./docs:/app/docs:ro

--- a/docs/streamlit.md
+++ b/docs/streamlit.md
@@ -8,7 +8,7 @@ The repository uses a minimal Streamlit app to present Markdown files from `docs
 
 ## Traefik Routing
 
-A typical `docker-compose` setup routes HTTPS traffic through Traefik to the Streamlit container:
+A typical `docker compose` setup routes HTTPS traffic through Traefik to the Streamlit container:
 
 ```yaml
 volumes:

--- a/docs/user_scenarios.md
+++ b/docs/user_scenarios.md
@@ -46,4 +46,4 @@
     - "traefik.http.routers.<svc>.rule=Host(`<your-domain>`)
     - "traefik.http.services.<svc>.loadbalancer.server.port=<port>"
   ```
-  If Traefik returns 404, add the above labels to the service in your `docker-compose`.
+  If Traefik returns 404, add the above labels to the service in your `docker-compose.yml`.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -16,7 +16,7 @@ Get your monitoring stack up and running with one command using a Docker Compose
 
 ## Makefile
 
-[Note](https://docs.docker.com/compose/install/linux/): Due to `docker-compose` and the `compose` plugin, you might have one of the two installed. I have a `Makefile` that will detect which on you have installed.
+[Note](https://docs.docker.com/compose/install/linux/): Depending on your Docker setup, you might have the legacy `docker-compose` binary or the newer `docker compose` plugin. The `Makefile` detects whichever is available.
 
 You can list the targets using `make`.
 
@@ -25,13 +25,13 @@ You can list the targets using `make`.
 Boot the stack with docker compose (or `make up`):
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Ensure all containers are running:
 
 ```bash
-docker-compose ps
+docker compose ps
 ```
 
 The output should looke like this:
@@ -114,5 +114,5 @@ The following endpoints are available:
 To remove the containers using docker compose (or `make clean`):
 
 ```bash
-docker-compose down
+docker compose down
 ```

--- a/mt5_gateway/README.md
+++ b/mt5_gateway/README.md
@@ -14,7 +14,7 @@ Repository Layout
 - supervisord.conf: example program section if using supervisord.
 
 How It’s Wired Here
-- docker-compose mounts this directory into the MT5 container at /opt/mt5_gateway (read-only).
+- Docker Compose mounts this directory into the MT5 container at /opt/mt5_gateway (read-only).
 - The MT5 container already runs a Flask MT5 API on port 5001 via Wine Python.
 - To avoid conflicts, the FastAPI gateway is disabled by default and, when enabled, uses port 5002 by default.
 


### PR DESCRIPTION
## Summary
- adopt `docker compose` as project-wide convention
- update README and documentation to use `docker compose`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c1e64511388328aece68f2a435533c