### PR TITLE
Remove markdown fence from WyckoffAdvanced page

### DIFF
--- a/dashboard/pages/15_ WyckoffAdvanced.py
+++ b/dashboard/pages/15_ WyckoffAdvanced.py
@@ -1,4 +1,3 @@
-```python
 import pandas as pd
 import numpy as np
 import plotly.graph_objects as go


### PR DESCRIPTION
## Summary
- Remove leftover Markdown code fence at the top of `15_ WyckoffAdvanced.py` to make it valid Python.

## Testing
- `python -m py_compile dashboard/pages/15_\ WyckoffAdvanced.py`


------
https://chatgpt.com/codex/tasks/task_b_68c1e745fd508328ba3b4405bc43fb8b