### PR TITLE
Fix VIX retrieval in macro dashboard

### DIFF
--- a/dashboard/pages/03_ 📰 MACRO & NEWS.py
+++ b/dashboard/pages/03_ 📰 MACRO & NEWS.py
@@ -2032,7 +2032,7 @@ Only include risk situations and actionable warnings relevant for today's sessio
             st.markdown(f"<div style='font-size:1.11rem; background:rgba(255,255,50,0.10); border-radius:8px; padding:0.8em 1em; color:#fff; margin-bottom:0.8em;'>{ai_risk_summary}</div>", unsafe_allow_html=True)
         vix_val = None
         try:
-            vix_val = prices.get("VIX", {}).get("current", "N/A")
+            vix_val = snapshot.get("vix_quote", {}).get("current", "N/A")
         except Exception:
             vix_val = "N/A"
         # --- Legacy risk alert logic ---


### PR DESCRIPTION
## Summary
- Use `snapshot` to retrieve VIX data in macro/news dashboard
- Remove leftover `prices` lookup to avoid undefined variable errors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus', RuntimeError: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1e72d072c8328a77f44cd56c967b1