### PR TITLE
Fix WordPress Traefik labels

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -668,8 +668,8 @@ services:
       traefik.enable: true
       traefik.docker.network: traefik-public
       traefik.http.routers.wiki.rule: Host(`info.zanalytics.app`)
-      traefik.http.routers.wiki.entrypoints: websecure
-      traefik.http.routers.wiki.tls.certresolver: letsencrypt
+      traefik.http.routers.wiki.entrypoints: https
+      traefik.http.routers.wiki.tls.certresolver: le
       traefik.http.services.wiki.loadbalancer.server.port: 80
 
   # whisperer-mcp service removed; see docs/mcp-audit-trail.md for audit history


### PR DESCRIPTION
## Summary
- Correct Traefik router entrypoint and certresolver labels for the WordPress service

## Testing
- `docker-compose config -q` *(fails: Missing mandatory value for "labels" option interpolating {...} in service "grafana")*
- `docker-compose up -d wordpress` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))*
- `curl -I https://info.zanalytics.app` *(HTTP/1.1 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_68c1e7b095308328a0e6ae1b1b2e934c