### PR TITLE
style: format phase color mapping

### DIFF
--- a/dashboard/pages/15_ WyckoffAdvanced.py
+++ b/dashboard/pages/15_ WyckoffAdvanced.py
@@ -145,7 +145,13 @@ if st.sidebar.button("Fetch Data") or auto_refresh:
                                          low=analyzed['low'], close=analyzed['close']), row=1, col=1)
             
             # Phases (simplified coloring)
-            phase_colors = {'Accumulation':'blue', 'Distribution':'red', 'Markup':'green', 'Markdown':'orange', 'Neutral':'gray'}
+            phase_colors = {
+                "Accumulation": "blue",
+                "Distribution": "red",
+                "Markup": "green",
+                "Markdown": "orange",
+                "Neutral": "gray",
+            }
             for phase, color in phase_colors.items():
                 phase_df = analyzed[analyzed['phase'] == phase]
                 if not phase_df.empty:


### PR DESCRIPTION
## Summary
- format Wyckoff phase color dictionary with explicit mapping

## Testing
- `python -m py_compile dashboard/pages/15_ WyckoffAdvanced.py`


------
https://chatgpt.com/codex/tasks/task_b_68c1e9f8328c83288626bd44ddd5a089