### PR TITLE
Include utils in MCP Docker image

### DIFF
--- a/backend/mcp/Dockerfile
+++ b/backend/mcp/Dockerfile
@@ -3,4 +3,5 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY mcp_server.py openai-actions.yaml .
+COPY utils /app/utils/
 CMD ["uvicorn", "mcp_server:app", "--host", "0.0.0.0", "--port", "8001"]


### PR DESCRIPTION
## Summary
- Copy root-level `utils` directory into MCP Docker image to provide shared utilities

## Testing
- `pytest` *(fails: ModuleNotFoundError and RuntimeError)*
- `docker build -t mcp:latest -f backend/mcp/Dockerfile .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_b_68c1ee77a40c832887e01ea5e6f0ac58