### PR TITLE
feat(mcp): add prometheus metrics

### DIFF
--- a/monitoring/configs/prometheus/prometheus.yml
+++ b/monitoring/configs/prometheus/prometheus.yml
@@ -42,6 +42,7 @@ scrape_configs:
         labels:
           container: "cadvisor"
   - job_name: mcp
+    metrics_path: /metrics
     static_configs:
       - targets: ["mcp:8001"]
         labels:

--- a/monitoring/configs/promtail/promtail.yaml
+++ b/monitoring/configs/promtail/promtail.yaml
@@ -30,6 +30,10 @@ scrape_configs:
         regex: '/mcp'
         target_label: 'job'
         replacement: 'mcp'
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/mcp'
+        target_label: 'service'
+        replacement: 'mcp'
     pipeline_stages:
       - cri: {}
       - multiline:


### PR DESCRIPTION
## Summary
- track MCP requests and heartbeat status with Prometheus metrics
- expose metrics endpoint and configure Prometheus/Promtail scraping

## Testing
- `pytest tests/test_mcp_exec_search.py tests/test_mcp_auth.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c1f03689048328b711e32a57437aca