### PR TITLE
Explicitly register Prometheus metrics

### DIFF
--- a/backend/mcp/mcp_server.py
+++ b/backend/mcp/mcp_server.py
@@ -23,6 +23,7 @@ from prometheus_client import (
     Gauge,
     generate_latest,
     CONTENT_TYPE_LATEST,
+    REGISTRY,
 )
 
 mt5_adapter.init_mt5()
@@ -136,7 +137,7 @@ async def exec_proxy(request: Request, full_path: str):
 @app.get("/metrics")
 def metrics():
     REQUESTS.labels(endpoint="metrics").inc()
-    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+    return Response(generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST)
 
 
 class PositionOpen(BaseModel):


### PR DESCRIPTION
## Summary
- import REGISTRY from prometheus_client
- generate /metrics using generate_latest(REGISTRY)

## Testing
- `pytest` *(fails: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c1f2f5fb648328a691a8b726db39eb