### PR TITLE
Refactor MCP server import for mt5 adapter

### DIFF
--- a/backend/mcp/mcp_server.py
+++ b/backend/mcp/mcp_server.py
@@ -11,13 +11,15 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - allow module to import without pandas
     pd = None
 from pathlib import Path
+import sys
 from dotenv import load_dotenv
 from utils.time import localize_tz
 try:  # pragma: no cover - optional dependency
     import MetaTrader5 as mt5  # type: ignore
 except Exception:  # pragma: no cover - allow module to import without MT5
     mt5 = None
-from . import mt5_adapter
+sys.path.append(str(Path(__file__).resolve().parent))
+from mt5_adapter import init_mt5
 from prometheus_client import (
     Counter,
     Gauge,
@@ -25,7 +27,7 @@ from prometheus_client import (
     CONTENT_TYPE_LATEST,
 )
 
-mt5_adapter.init_mt5()
+init_mt5()
 
 app = FastAPI(title="Zanalytics MCP Server")
 


### PR DESCRIPTION
## Summary
- use absolute import for `mt5_adapter` in MCP server
- call `init_mt5` directly after updating module path

## Testing
- `pytest tests/test_mcp_auth.py tests/test_mcp_exec_search.py` *(fails: KeyboardInterrupt - MT5 not ready)*

------
https://chatgpt.com/codex/tasks/task_b_68c1f2e92e688328a01a99b12f771242