### PR TITLE
Handle MetaTrader5 import failure and simplify init

### DIFF
--- a/backend/mcp/mt5_adapter.py
+++ b/backend/mcp/mt5_adapter.py
@@ -1,14 +1,17 @@
-import time
-import MetaTrader5 as mt5
+try:
+    import MetaTrader5 as mt5
+except Exception:
+    mt5 = None
 
 
 def init_mt5():
-    """Initialize connection to MetaTrader5 with retries."""
+    """Initialize connection to MetaTrader5."""
+    if mt5 is None:
+        return False
     if not mt5.initialize():
-        print("MT5 not ready - retrying...")
-        time.sleep(5)
-        return init_mt5()
+        raise RuntimeError("MetaTrader5 initialization failed")
     print("MT5 bridged.")
+    return True
 
 
 __all__ = ["init_mt5"]


### PR DESCRIPTION
## Summary
- handle missing MetaTrader5 module gracefully
- simplify `init_mt5` to initialize once and raise on failure
- export only the `init_mt5` function

## Testing
- `pytest` *(fails: RuntimeError: MetaTrader5 initialization failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c1f72ef170832880fb399edcb2e490