### PR TITLE
chore: add pydocstyle linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -c constraints.txt
+          pip install .[lint]
+      - name: Lint docstrings
+        run: make lint-docs
       - name: Validate action routes
         run: python scripts/validate_actions.py
       - name: Run pytest

--- a/.github/workflows/pulse_tests.yml
+++ b/.github/workflows/pulse_tests.yml
@@ -29,6 +29,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt -c constraints.txt
         pip install pytest pytest-cov
+        pip install .[lint]
+
+    - name: Lint docstrings
+      run: make lint-docs
 
     - name: Run Pulse tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ bot:
 # Run Streamlit dashboard locally (multi-page)
 dashboard:
 	streamlit run app.py
+
+# Lint Python docstrings
+lint-docs:
+	pydocstyle src tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ dependencies = [
   "redis>=4.5",
 ]
 
+[project.optional-dependencies]
+lint = [
+  "pydocstyle",
+]
+
 [tool.setuptools]
 include-package-data = true
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Test configuration and MT5 stubs used across the suite."""
+
 import sys
 from types import SimpleNamespace
 


### PR DESCRIPTION
## Summary
- add pydocstyle optional dependency and lint target
- check docstrings in CI workflows
- document tests for MT5 stubs

## Testing
- `make lint-docs`
- `pytest -m "not mt5" -q` *(fails: MetaTrader5 initialization failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c1fa2114f88328b1370ab7da6d0b3f