### PR TITLE
fix dashboard safe_api_call import path

### DIFF
--- a/dashboard/Home.py
+++ b/dashboard/Home.py
@@ -59,7 +59,7 @@ from typing import Dict, Optional
 import base64
 import yfinance as yf
 from fredapi import Fred
-from utils.streamlit_api import safe_api_call
+from dashboard.utils.streamlit_api import safe_api_call
 import os
 import requests
 import redis


### PR DESCRIPTION
## Summary
- fix dashboard import for safe_api_call to use dashboard.utils module

## Testing
- `streamlit run dashboard/Home.py --server.headless true --server.port 8888`
- `python -m py_compile dashboard/Home.py`


------
https://chatgpt.com/codex/tasks/task_b_68c1fd130c1c83289f099f878ed93fef