### PR TITLE
Replace placeholder Streamlit call in macro news page

### DIFF
--- a/dashboard/pages/03_ 📰 MACRO & NEWS.py
+++ b/dashboard/pages/03_ 📰 MACRO & NEWS.py
@@ -2004,7 +2004,7 @@ for sig in ops:
     with st.expander(f"{sig.get('symbol','?')} • {sig.get('bias','?')} • SL {sig.get('sl','?')} TP {sig.get('tp','?')}"):
         st.write(sig.get("reason", "No reason provided"))
         if sig.get("explain"):
-            st        # Risk warnings
+            st.write(sig.get("explain"))  # Risk warnings
         st.subheader("⚠️ Risk Alerts")
 
         risk_alerts = []
@@ -2023,7 +2023,7 @@ for sig in ops:
             with st.expander(f"{sig.get('symbol','?')} • {sig.get('bias','?')} • SL {sig.get('sl','?')} TP {sig.get('tp','?')}"):
                 st.write(sig.get("reason", "No reason provided"))
                 if sig.get("explain"):
-                    st        # Risk warnings
+                    st.write(sig.get("explain"))  # Risk warnings
                 st.subheader("⚠️ Risk Alerts")
 
                 risk_alerts = []


### PR DESCRIPTION
## Summary
- Display signal explanations in Top Opportunities by calling `st.write(sig.get("explain"))` instead of a placeholder `st`.

## Testing
- `python -m py_compile "dashboard/pages/03_ 📰 MACRO & NEWS.py"` *(fails: SyntaxError: invalid syntax at line 2036)*

------
https://chatgpt.com/codex/tasks/task_b_68c1fca86cdc8328b00dc391eac10b22