### PR TITLE
Fix indentation in Home2 expanders

### DIFF
--- a/dashboard/pages/Home2.py
+++ b/dashboard/pages/Home2.py
@@ -473,42 +473,42 @@ class ZanalyticsDashboard:
 
             # Agent Ops — Quick Checklist (price integrity)
             with st.expander("Price Confirmation Checklist", expanded=False):
-            st.markdown(
-                "- Confirm latest price via `/api/v1/feed/bars-enriched` (preferred)\n"
-                "- If primary feed is down, use Yahoo chart API (e.g., `XAUUSD=X`, `GC=F`)\n"
-                "- Never state a price if no feed is reachable\n"
-                "- When quoting, include instrument + timeframe + time (e.g., M15 close at 13:45Z)"
-            )
-            st.caption("See full guidance in Agent Ops → GPT Instructions below.")
+                st.markdown(
+                    "- Confirm latest price via `/api/v1/feed/bars-enriched` (preferred)\n"
+                    "- If primary feed is down, use Yahoo chart API (e.g., `XAUUSD=X`, `GC=F`)\n"
+                    "- Never state a price if no feed is reachable\n"
+                    "- When quoting, include instrument + timeframe + time (e.g., M15 close at 13:45Z)"
+                )
+                st.caption("See full guidance in Agent Ops → GPT Instructions below.")
 
             # Agent Ops — GPT Instructions (inline reference)
             with st.expander("Agent Ops — GPT Instructions", expanded=False):
-            try:
-                from pathlib import Path
-                p = Path(__file__).resolve().parents[2] / "docs" / "custom_gpt_instructions.md"
-                text = p.read_text(encoding="utf-8") if p.exists() else ""
-                if text:
-                    st.markdown(text)
-                else:
-                    st.info("Instructions file not found: docs/custom_gpt_instructions.md")
-            except Exception:
-                st.info("Unable to load instructions.")
+                try:
+                    from pathlib import Path
+                    p = Path(__file__).resolve().parents[2] / "docs" / "custom_gpt_instructions.md"
+                    text = p.read_text(encoding="utf-8") if p.exists() else ""
+                    if text:
+                        st.markdown(text)
+                    else:
+                        st.info("Instructions file not found: docs/custom_gpt_instructions.md")
+                except Exception:
+                    st.info("Unable to load instructions.")
 
 
             # Directory scanning/parquet dependency removed — live and DB feeds only
 
             # --- Tick Data from API ---
             with st.expander("📡 Tick Data – XAUUSD (Last 100 Ticks)", expanded=False):
-            try:
-                df_ticks = self.fetch_tick_data("XAUUSD", 100)
-                if df_ticks.empty:
-                    st.warning("No tick data received from API.")
-                else:
-                    # Show basic columns if available
-                    cols = [c for c in ['timestamp', 'bid', 'ask', 'last', 'volume'] if c in df_ticks.columns]
-                    st.dataframe(df_ticks[cols])
-            except Exception as e:
-                st.error(f"Failed to load tick data: {e}")
+                try:
+                    df_ticks = self.fetch_tick_data("XAUUSD", 100)
+                    if df_ticks.empty:
+                        st.warning("No tick data received from API.")
+                    else:
+                        # Show basic columns if available
+                        cols = [c for c in ['timestamp', 'bid', 'ask', 'last', 'volume'] if c in df_ticks.columns]
+                        st.dataframe(df_ticks[cols])
+                except Exception as e:
+                    st.error(f"Failed to load tick data: {e}")
 
             # Move straight into main content (no local directory scan)
             self.display_home_page(None)


### PR DESCRIPTION
## Summary
- Ensure expander sections in `Home2` correctly wrap their content
- Keep tick data retrieval inside the expander with consistent indentation

## Testing
- `python -m py_compile dashboard/pages/Home2.py`
- `pytest -q` *(fails: No module named 'app.nexus', MetaTrader5 initialization failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c1fef88f508328b364fc5145217b1a