### PR TITLE
docs: document env_file usage for mcp service

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ Before starting, install the core tooling: [Git](https://git-scm.com/book/en/v2/
 
 ## Environment Variables
 
+Copy `.env.template` to `.env`, fill in the sensitive values, and keep the real
+file out of version control. Docker Compose reads `.env` through its `env_file`
+directive and injects those variables into services like `mcp`. In CI pipelines,
+provide the same variables via your environment or secret manager—containers no
+longer mount `.env` directly.
+
 Key variables to configure before launching:
 
 - `CUSTOM_USER` and `PASSWORD` – MT5 account credentials.
@@ -129,7 +135,8 @@ Key variables to configure before launching:
 - `BRIDGE_TOKEN` – optional token sent as `X-Bridge-Token` header.
 - `VNC_DOMAIN`, `TRAEFIK_DOMAIN`, `TRAEFIK_USERNAME`, `ACME_EMAIL` – domains and Traefik settings.
 - `DJANGO_SECRET_KEY` – secret key for Django.
-- `MCP_API_KEY` – MCP uses the root `.env`; set this 32‑hex‑character key there. This key is shared across services so Whisperer connects once without drift.
+- `MCP_API_KEY` – secret used by the `mcp` service. Add it to `.env` and Compose
+  or CI will inject it; use a 32‑hex‑character value.
 
 For the complete list of variables, see [docs/env-reference.md](docs/env-reference.md).
 

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -1,6 +1,15 @@
 # Environment Variable Reference
 
-This document lists the environment variables defined in [`.env.template`](../.env.template). Copy the template to `.env` and adjust values for your setup. Values defined in `.env` or in the shell environment override the defaults shown here.
+This document lists the environment variables defined in [`.env.template`](../.env.template).
+Start by copying that template to a new `.env` file and filling in your own secrets.
+**Never commit the populated `.env` file to version control.**
+
+For local development, Docker Compose reads `.env` via its `env_file` directive and
+injects the values into services like `mcp`. In CI environments, provide the same
+variables through your pipeline's environment or secret store. The container no
+longer mounts `.env` directly.
+
+Values defined in `.env` or in the shell environment override the defaults shown here.
 
 ## Core Database Settings
 | Variable | Default | Override Behavior | Purpose |


### PR DESCRIPTION
## Summary
- clarify .env handling for mcp; compose now uses `env_file` or CI secrets
- note to copy `.env.template` to `.env`, set secrets, and keep out of git
- document that containers no longer mount `.env`

## Testing
- `pytest` *(fails: RuntimeError populate() isn't reentrant, MetaTrader5 initialization failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c2056e09f0832898dc83faadf60425