### PR TITLE
docs: document Loki and Promtail log pipeline

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,7 +1,12 @@
 # Monitoring
 
-This project uses a Prometheus, Grafana, and Alertmanager stack to observe
-application and infrastructure health.
+This project uses a Prometheus, Grafana, Alertmanager, Loki, and Promtail stack
+to observe application and infrastructure health.
+
+```
+metrics: services -> Prometheus -> Grafana -> Alertmanager
+logs:    containers -> Promtail -> Loki -> Grafana
+```
 
 ## Prometheus scraping
 
@@ -12,10 +17,20 @@ database for querying and alert evaluation.
 
 ## Grafana dashboards
 
-Grafana connects to Prometheus as a data source. Prebuilt dashboards visualize
-node statistics, container performance, and application metrics. The Grafana UI
-is available at `http://localhost:3000`, and additional dashboards can be added
-or customized to suit operational needs.
+Grafana connects to Prometheus and Loki as data sources. Prebuilt dashboards
+visualize node statistics, container performance, application metrics, and
+centralized logs. The Grafana UI is available at `http://localhost:3000`, and
+additional dashboards can be added or customized to suit operational needs.
+
+## Log pipeline
+
+Promtail tails container logs and forwards them to Loki for centralized
+storage. The configuration at `monitoring/configs/promtail/promtail.yaml`
+targets containers labeled with `logging=promtail`, exposes metrics on
+`http://localhost:9080`, and pushes log entries to `http://loki:3100`. Loki's
+API is reachable at `http://localhost:3100`, and logs can be explored in
+Grafana's **Explore** view at `http://localhost:3000` using the Loki data
+source.
 
 ## Alertmanager behavior
 


### PR DESCRIPTION
## Summary
- document Loki and Promtail log pipeline alongside existing monitoring stack
- expand Grafana section to include Loki as a data source

## Testing
- `pytest` *(fails: RuntimeError populate() isn't reentrant / MetaTrader5 initialization failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c206f5b2dc83289c8f6bb3db07e712