### PR TITLE
Use dependency-based API key auth for MCP server

### DIFF
--- a/backend/mcp/auth.py
+++ b/backend/mcp/auth.py
@@ -1,0 +1,19 @@
+import os
+from fastapi import Header, HTTPException, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+security = HTTPBearer(auto_error=False)
+
+def _get_expected_key() -> str:
+    return os.environ.get("MCP_API_KEY", "")
+
+async def verify_api_key(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+    x_api_key: str | None = Header(default=None),
+) -> None:
+    """Validate API key from Authorization or X-API-Key headers."""
+    expected = _get_expected_key()
+    provided = credentials.credentials if credentials else x_api_key
+    if not provided or provided != expected:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -24,7 +24,6 @@ def test_mcp_public(monkeypatch):
 
 def test_exec_requires_api_key(monkeypatch):
     monkeypatch.setenv("MCP_API_KEY", TEST_KEY)
-    monkeypatch.setattr(mcp_server, "API_KEY", TEST_KEY)
 
     assert client.get("/exec/foo").status_code == 401
     assert client.get("/exec/foo", headers={"X-API-Key": "wrong"}).status_code == 401
@@ -32,7 +31,6 @@ def test_exec_requires_api_key(monkeypatch):
 
 def test_exec_with_valid_api_key(monkeypatch):
     monkeypatch.setenv("MCP_API_KEY", TEST_KEY)
-    monkeypatch.setattr(mcp_server, "API_KEY", TEST_KEY)
 
     class MockResponse:
         def __init__(self):
@@ -49,6 +47,6 @@ def test_exec_with_valid_api_key(monkeypatch):
 
     monkeypatch.setattr(httpx.AsyncClient, "request", mock_request)
 
-    response = client.get("/exec/foo", headers={"X-API-Key": mcp_server.API_KEY})
+    response = client.get("/exec/foo", headers={"X-API-Key": TEST_KEY})
     assert response.status_code == 200
     assert response.json() == {"ok": True}

--- a/tests/test_mcp_exec_search.py
+++ b/tests/test_mcp_exec_search.py
@@ -13,7 +13,6 @@ TEST_KEY = "test-key"
 
 def setup_api_key(monkeypatch):
     monkeypatch.setenv("MCP_API_KEY", TEST_KEY)
-    monkeypatch.setattr(mcp_server, "API_KEY", TEST_KEY)
 
 
 def test_exec_action_open_success(monkeypatch):


### PR DESCRIPTION
## Summary
- add verify_api_key dependency supporting Authorization or X-API-Key
- remove middleware-based auth and require dependency on MCP routes
- update tests for new auth flow

## Testing
- `pytest tests/test_mcp_auth.py tests/test_mcp_exec_search.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68c2070225188328b2f01a386c5f73ba