### PR TITLE
Add Docker setup for info Streamlit service

### DIFF
--- a/services/info/.streamlit/config.toml
+++ b/services/info/.streamlit/config.toml
@@ -1,0 +1,4 @@
+[server]
+headless = true
+enableCORS = false
+enableXsrfProtection = false

--- a/services/info/Dockerfile
+++ b/services/info/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY docs/wiki /app/wiki
+COPY dashboards/info /app/dashboards/info
+
+ENV PIP_ROOT_USER_ACTION=ignore
+RUN pip install --no-cache-dir streamlit==1.37.1 markdown==3.6
+
+CMD ["streamlit", "run", "/app/dashboards/info/main.py", "--server.port=${WIKI_DASHBOARD_PORT}", "--server.address=0.0.0.0"]


### PR DESCRIPTION
## Summary
- Add Dockerfile for info service using Python 3.12 and Streamlit
- Include Streamlit config enabling headless mode with CORS and XSRF disabled

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c209c5339083288e48f8f0c08b8fb3