### PR TITLE
chore: remove WordPress dashboard export

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ For deeper architecture insights and API details, visit the [docs README](docs/R
 - [FAQ](#faq)
 - [Troubleshooting Gold Mine](#troubleshooting-gold-mine)
 - [Pulse Dashboard Prototype](#pulse-dashboard-prototype)
-- [Exporting Streamlit Dashboards to WordPress](#exporting-streamlit-dashboards-to-wordpress)
 - [Further Reading](#further-reading)
 
 ## What's Inside
@@ -400,12 +399,6 @@ See [docs/mcp_troubleshooting.md](docs/mcp_troubleshooting.md) for Traefik label
 ## Pulse Dashboard Prototype
 
 Behavioral and risk analytics demo. [docs/pulse_dashboard_prototype.md](docs/pulse_dashboard_prototype.md).
-
----
-
-## Exporting Streamlit Dashboards to WordPress
-
-Static export workflow for publishing dashboards on WordPress. [docs/export_dashboards_wordpress.md](docs/export_dashboards_wordpress.md).
 
 ---
 

--- a/docs/export_dashboards_wordpress.md
+++ b/docs/export_dashboards_wordpress.md
@@ -1,8 +1,0 @@
-# Exporting Streamlit Dashboards to WordPress
-
-1. Run `scripts/export_dashboards.sh` to export dashboards as static HTML.
-2. The script copies the generated files into `wordpress/wp-content/uploads/dashboards/`.
-3. Activate the **Zanalytics Dashboards** plugin in WordPress (`wordpress/wp-content/plugins/zanalytics-dashboards`).
-4. Embed a dashboard on any page using `[zan_dashboard name="Home"]` where `Home` matches the exported filename.
-
-Once uploaded, dashboards render at `info.zanalytics.app` via the shortcode.

--- a/scripts/export_dashboards.sh
+++ b/scripts/export_dashboards.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Export Streamlit dashboards to static HTML and copy to WordPress uploads.
+# Export Streamlit dashboards to static HTML for the info site.
 # Usage: scripts/export_dashboards.sh [source_dir]
 # Default source_dir is 'pages'.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC_DIR="${1:-$ROOT_DIR/pages}"
-DEST_DIR="$ROOT_DIR/wordpress/wp-content/uploads/dashboards"
+DEST_DIR="$ROOT_DIR/docs/dashboards"
 
 mkdir -p "$DEST_DIR"
 
@@ -18,6 +18,7 @@ for app in "$SRC_DIR"/*.py; do
   streamlit static "$app" -o "$tmpdir"
   mv "$tmpdir"/index.html "$DEST_DIR/$name.html"
   rm -rf "$tmpdir"
+
 done
 
 echo "Dashboards exported to $DEST_DIR"


### PR DESCRIPTION
## Summary
- repoint dashboard export script to docs/dashboards for info site
- drop WordPress export documentation and references

## Testing
- `pytest` *(fails: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c209dfe6b48328a7fc5f066776e1ef