### PR TITLE
docs: update wiki dashboard run command

### DIFF
--- a/pages/RiskOpsRunbook.py
+++ b/pages/RiskOpsRunbook.py
@@ -19,8 +19,7 @@ def render(mock_data):
     st.write("Weekly reviews: Detect drift via behavior_events.")
     st.subheader("Operations")
     st.write(
-        "Run: streamlit run dashboard/wiki_dashboard.py --server.port="
-        "{st.secrets.get('WIKI_DASHBOARD_PORT', 8503)}"
+        f"Run: streamlit run dashboards/info/main.py --server.port={st.secrets.get('WIKI_DASHBOARD_PORT', 8503)}"
     )
     st.write("Route: Traefik host WIKI_DASHBOARD; verify Django health /api/pulse/health.")
     with st.expander("Incident Checklist"):

--- a/wiki_pages/risk_ops_runbook.py
+++ b/wiki_pages/risk_ops_runbook.py
@@ -20,8 +20,7 @@ def render(mock_data):
     st.write("Weekly reviews: Detect drift via behavior_events.")
     st.subheader("Operations")
     st.write(
-        "Run: streamlit run dashboard/wiki_dashboard.py --server.port="
-        "{st.secrets.get('WIKI_DASHBOARD_PORT', 8503)}"
+        f"Run: streamlit run dashboards/info/main.py --server.port={st.secrets.get('WIKI_DASHBOARD_PORT', 8503)}"
     )
     st.write("Route: Traefik host WIKI_DASHBOARD; verify Django health /api/pulse/health.")
     with st.expander("Incident Checklist"):


### PR DESCRIPTION
## Summary
- point wiki dashboard run instructions to `dashboards/info/main.py`
- ensure port references use `WIKI_DASHBOARD_PORT`

## Testing
- `pytest` *(fails: populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c209d658d883288c5535b6301bab8b