### PR TITLE
feat(mcp): add typed actions query

### DIFF
--- a/backend/mcp/models.py
+++ b/backend/mcp/models.py
@@ -1,0 +1,46 @@
+"""Pydantic models for the MCP server."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+# Enumerated action names accepted by the Actions Bus.
+WHISPER_SUGGEST = "whisper_suggest"
+SESSION_BOOT = "session_boot"
+TRADES_RECENT = "trades_recent"
+TRADES_HISTORY_MT5 = "trades_history_mt5"
+ACCOUNT_POSITIONS = "account_positions"
+
+ActionType = Literal[
+    WHISPER_SUGGEST,
+    SESSION_BOOT,
+    TRADES_RECENT,
+    TRADES_HISTORY_MT5,
+    ACCOUNT_POSITIONS,
+]
+
+
+class ActionsQuery(BaseModel):
+    """Request model for ``POST /api/v1/actions/query``.
+
+    Attributes:
+        type: Enumerated action name to execute.
+        approve: Skip UI confirmations when ``True``.
+        payload: Optional data required by the action.
+    """
+
+    type: ActionType
+    approve: bool = False
+    payload: dict | None = None
+
+
+__all__ = [
+    "ACCOUNT_POSITIONS",
+    "ActionType",
+    "ActionsQuery",
+    "SESSION_BOOT",
+    "TRADES_HISTORY_MT5",
+    "TRADES_RECENT",
+    "WHISPER_SUGGEST",
+]


### PR DESCRIPTION
## Summary
- create `ActionsQuery` model with enumerated action types
- use typed handler mapping and clearer 422 error on unknown action type

## Testing
- `pytest tests/test_mcp_auth.py tests/test_mcp_exec_search.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68c20c5120948328b139ec986d31fd98