### PR TITLE
docs: drop WordPress export section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,6 @@ Static Info Site
 ----------------
 
 - The public info site is a static hub synced directly from this repository's `docs/` directory.
-- No WordPress backend or other dynamic CMS is involved.
 - Deploy by serving the static content via tools like Streamlit or MkDocs behind Traefik.
 - Streamlit setup details are in [streamlit.md](streamlit.md).
 

--- a/docs/streamlit.md
+++ b/docs/streamlit.md
@@ -25,3 +25,5 @@ labels:
 - Each Markdown file becomes a page on the public info site.
 
 This setup keeps the site in sync with the repository; pushing changes to `docs/` updates the live content.
+
+For the dedicated info container and deployment details, see [info-site.md](info-site.md).


### PR DESCRIPTION
## Summary
- remove outdated WordPress export reference from docs
- note info-site.md as the source for the new info container

## Testing
- `./docs/validate.sh` *(fails: Key missing or inconsistent – fix .env or code.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.nexus')*

------
https://chatgpt.com/codex/tasks/task_b_68c20c19acf88328941ac4300d3e84ab