### PR TITLE
test: verify MCP auth headers and health

### DIFF
--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -1,18 +1,23 @@
 import json
 import httpx
 from fastapi.testclient import TestClient
+import pytest
 import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import backend.mcp.mcp_server as mcp_server
 
-client = TestClient(mcp_server.app)
-
 TEST_KEY = "test-key"
 
 
-def test_mcp_public(monkeypatch):
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("MCP_API_KEY", TEST_KEY)
+    return TestClient(mcp_server.app)
+
+
+def test_mcp_public(monkeypatch, client):
     async def finite_stream():
         yield "open\n"
 
@@ -22,16 +27,20 @@ def test_mcp_public(monkeypatch):
     assert response.status_code == 200
 
 
-def test_exec_requires_api_key(monkeypatch):
-    monkeypatch.setenv("MCP_API_KEY", TEST_KEY)
-
+def test_exec_requires_api_key(client):
     assert client.get("/exec/foo").status_code == 401
-    assert client.get("/exec/foo", headers={"X-API-Key": "wrong"}).status_code == 401
+    assert (
+        client.get("/exec/foo", headers={"X-API-Key": "wrong"}).status_code == 401
+    )
+    assert (
+        client.get(
+            "/exec/foo", headers={"Authorization": "Bearer wrong"}
+        ).status_code
+        == 401
+    )
 
 
-def test_exec_with_valid_api_key(monkeypatch):
-    monkeypatch.setenv("MCP_API_KEY", TEST_KEY)
-
+def _mock_response():
     class MockResponse:
         def __init__(self):
             self.status_code = 200
@@ -42,11 +51,33 @@ def test_exec_with_valid_api_key(monkeypatch):
         def json(self):
             return self._data
 
+    return MockResponse()
+
+
+def test_exec_with_valid_x_api_key(client, monkeypatch):
     async def mock_request(self, *args, **kwargs):
-        return MockResponse()
+        return _mock_response()
 
     monkeypatch.setattr(httpx.AsyncClient, "request", mock_request)
 
     response = client.get("/exec/foo", headers={"X-API-Key": TEST_KEY})
     assert response.status_code == 200
     assert response.json() == {"ok": True}
+
+
+def test_exec_with_valid_bearer_token(client, monkeypatch):
+    async def mock_request(self, *args, **kwargs):
+        return _mock_response()
+
+    monkeypatch.setattr(httpx.AsyncClient, "request", mock_request)
+
+    response = client.get(
+        "/exec/foo", headers={"Authorization": f"Bearer {TEST_KEY}"}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_health_no_auth(client):
+    response = client.get("/health")
+    assert response.status_code == 200

--- a/tests/test_mcp_exec_search.py
+++ b/tests/test_mcp_exec_search.py
@@ -3,20 +3,21 @@ from fastapi.testclient import TestClient
 import json
 import sys
 from pathlib import Path
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import backend.mcp.mcp_server as mcp_server
 
-client = TestClient(mcp_server.app)
 TEST_KEY = "test-key"
 
 
-def setup_api_key(monkeypatch):
+@pytest.fixture
+def client(monkeypatch):
     monkeypatch.setenv("MCP_API_KEY", TEST_KEY)
+    return TestClient(mcp_server.app)
 
 
-def test_exec_action_open_success(monkeypatch):
-    setup_api_key(monkeypatch)
+def test_exec_action_open_success(monkeypatch, client):
 
     class MockResponse:
         status_code = 200
@@ -41,15 +42,13 @@ def test_exec_action_open_success(monkeypatch):
     assert resp.json() == {"ok": True}
 
 
-def test_exec_action_unsupported(monkeypatch):
-    setup_api_key(monkeypatch)
+def test_exec_action_unsupported(client):
     payload = {"type": "unknown", "payload": {}}
     resp = client.post("/exec", json=payload, headers={"X-API-Key": TEST_KEY})
     assert resp.status_code == 400
 
 
-def test_search_tool_success(monkeypatch):
-    setup_api_key(monkeypatch)
+def test_search_tool_success(monkeypatch, client):
 
     class MockResponse:
         status_code = 200
@@ -68,8 +67,7 @@ def test_search_tool_success(monkeypatch):
     assert resp.json() == {"results": ["XAUUSD", "EURUSD"]}
 
 
-def test_search_tool_api_error(monkeypatch):
-    setup_api_key(monkeypatch)
+def test_search_tool_api_error(monkeypatch, client):
 
     async def mock_get(self, url):
         raise httpx.ConnectError("boom")


### PR DESCRIPTION
## Summary
- switch MCP tests to fixture that sets `MCP_API_KEY`
- add coverage for `Authorization: Bearer` and missing headers
- ensure `/health` works without auth and update exec/search tests

## Testing
- `pytest tests/test_mcp_auth.py tests/test_mcp_exec_search.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68c20db9aa6483289150d531bccebe77