### PR TITLE
docs: show dual auth headers and add health endpoint example

### DIFF
--- a/docs/api-security.md
+++ b/docs/api-security.md
@@ -1,34 +1,28 @@
 # API Security
 
-## Setting and rotating `X-API-Key`
+## Setting and rotating the API key
 
-- Set the `X-API-Key` value in an environment variable named `MCP_API_KEY`. Avoid hard-coding it in source code or configuration files.
+- Set the API key value in an environment variable named `MCP_API_KEY`. Avoid hard-coding it in source code or configuration files.
 - Rotate the key on a regular schedule and update `MCP_API_KEY` accordingly.
 - For local development you can use a test value such as `dev-key-123`.
 
 ## Public vs. protected endpoints
 
-- `/mcp` is a public heartbeat endpoint and requires no authentication.
-- Other routes, like `POST /api/v1/actions/query` or `/exec/...`, must include the `X-API-Key` header.
+- `/mcp` and `/health` are public heartbeat endpoints and require no authentication.
+- Other routes, like `POST /api/v1/actions/query` or `/exec/...`, must include both the `Authorization: Bearer <key>` and `X-API-Key: <key>` headers.
 
 ## Curl example
 
 ```bash
-
-curl -s -H "X-API-Key: dev-key-123" -X POST \
-  http://localhost:8080/api/v1/actions/query -d '{"type":"session_boot"}'
-# Omitting the header returns 401 Unauthorized
-curl -s -X POST http://localhost:8080/api/v1/actions/query -d '{"type":"session_boot"}'
-
 curl -sX POST http://localhost:8080/api/v1/actions/query \
+  -H "Authorization: Bearer dev-key-123" \
   -H "X-API-Key: dev-key-123" \
   -H "Content-Type: application/json" \
   -d '{"type":"session_boot","payload":{"user_id":"demo"}}'
-# Omitting the header returns 401 Unauthorized
+# Omitting the headers returns 401 Unauthorized
 curl -sX POST http://localhost:8080/api/v1/actions/query \
   -H "Content-Type: application/json" \
   -d '{"type":"session_boot","payload":{"user_id":"demo"}}'
-
 ```
 
 The `Content-Type: application/json` header is required when sending JSON bodies.
@@ -40,6 +34,8 @@ See [auth](auth.md) for additional authentication examples and key rotation step
 In the OpenAI connector, configure:
 
 - **Authentication → Custom**
+- **Header Name:** `Authorization`
+- **Value:** `Bearer dev-key-123`
 - **Header Name:** `X-API-Key`
 - **Value:** `dev-key-123`
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,33 +1,31 @@
 # Authentication
 
-All HTTP requests to the MCP server must include the `X-API-Key` header, except for the `/mcp` heartbeat endpoint.
+All HTTP requests to the MCP server must include the `Authorization: Bearer <key>` and `X-API-Key: <key>` headers, except for the `/mcp` and `/health` heartbeat endpoints.
 
 ## Example request
 
 Use a development key such as `dev-key-123` during local testing:
 
 ```bash
-curl -s -H "X-API-Key: dev-key-123" -X POST \
-  http://localhost:8080/api/v1/actions/query \
-  -d '{"type": "session_boot"}'
-
-curl -s -H "X-API-Key: dev-key-123" \
+curl -sX POST http://localhost:8080/api/v1/actions/query \
+  -H "Authorization: Bearer dev-key-123" \
+  -H "X-API-Key: dev-key-123" \
   -H "Content-Type: application/json" \
-  -X POST \
-  -d '{ "type": "session_boot", "payload": {} }' \
-  http://localhost:8080/api/v1/actions/query
+  -d '{"type":"session_boot","payload":{}}'
 ```
 
 Minimal JSON body:
 
 ```json
 { "type": "session_boot", "payload": {} }
+```
 
+```bash
 curl -sX POST "http://localhost:8080/api/v1/actions/query" \
+  -H "Authorization: Bearer dev-key-123" \
   -H "X-API-Key: dev-key-123" \
   -H "Content-Type: application/json" \
   -d '{"type":"session_boot","payload":{"user_id":"demo"}}'
-
 ```
 
 The `Content-Type: application/json` header is required when sending JSON to the Actions Bus.
@@ -38,7 +36,7 @@ The server reads the key from the `MCP_API_KEY` environment variable. To rotate 
 
 1. Set a new value in your environment or `.env` file: `MCP_API_KEY=new-key`.
 2. Restart the service so it picks up the new key, e.g. `docker compose up --build mcp`.
-3. Update clients to send the new `X-API-Key` header.
+3. Update clients to send the new `Authorization` and `X-API-Key` headers.
 
 
 Last validated: 2025-09-10 15:07:51Z

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -116,10 +116,11 @@ docker compose restart mt5
 ```
 Verify ticks with `curl "$MT5_API_URL/ticks?symbol=EURUSD&limit=1"`.
 
-**Q: Which header carries the API key?**
-A: Use `X-API-Key` with the value from `$MCP_API_KEY`:
+**Q: Which headers carry the API key?**
+A: Send both `Authorization: Bearer $MCP_API_KEY` and `X-API-Key: $MCP_API_KEY`:
 ```bash
-curl -H "X-API-Key: $MCP_API_KEY" http://localhost:8001/api/...
+curl -H "Authorization: Bearer $MCP_API_KEY" \
+     -H "X-API-Key: $MCP_API_KEY" http://localhost:8001/api/...
 ```
 See [api-security.md](api-security.md) for rotation guidance.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,9 +56,10 @@ For MCP-specific routing and container issues, see [mcp_troubleshooting.md](mcp_
 - Validate ticks with `curl "$MT5_API_URL/ticks?symbol=EURUSD&limit=1"`.
 
 ## API Key Header Usage
-- Protected endpoints require `X-API-Key` headers.
+- Protected endpoints require both `Authorization: Bearer <key>` and `X-API-Key: <key>` headers.
 - Example:
   ```bash
-  curl -H "X-API-Key: $MCP_API_KEY" http://localhost:8001/api/...
+  curl -H "Authorization: Bearer $MCP_API_KEY" \
+       -H "X-API-Key: $MCP_API_KEY" http://localhost:8001/api/...
   ```
 - See [api-security.md](api-security.md) for rotation and storage details.


### PR DESCRIPTION
## Summary
- require both `Authorization: Bearer` and `X-API-Key` headers across auth docs
- document `/health` endpoint and valid `/api/v1/actions/query` request bodies
- fix malformed JSON in curl snippets

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.nexus')*


------
https://chatgpt.com/codex/tasks/task_b_68c20db62e6c8328bffa9f5cc08c7909