### PR TITLE
Use UUID for harmonic pattern IDs

### DIFF
--- a/utils/processors/harmonic.py
+++ b/utils/processors/harmonic.py
@@ -1,0 +1,34 @@
+"""Harmonic pattern processor utilities."""
+from __future__ import annotations
+
+from uuid import uuid4
+from typing import Dict
+
+import pandas as pd
+
+
+def build_qdrant_payload(df: pd.DataFrame) -> Dict:
+    """Attach a unique pattern identifier to ``df`` and create Qdrant payload.
+
+    Parameters
+    ----------
+    df:
+        DataFrame describing a harmonic pattern.
+
+    Returns
+    -------
+    Dict
+        Payload ready for Qdrant insertion. The unique ``pattern_id`` is
+        serialized to a string and applied to both the DataFrame and payload.
+    """
+    if df.empty:
+        return {}
+
+    pattern_id = str(uuid4())
+    df["pattern_id"] = pattern_id
+
+    payload = {
+        "pattern_id": pattern_id,
+        "points": df.to_dict(orient="records"),
+    }
+    return payload


### PR DESCRIPTION
## Summary
- add harmonic pattern processor that assigns a UUID-based `pattern_id`
- ensure the identifier is serialized to a string and applied to both the DataFrame and Qdrant payload

## Testing
- `pytest -q` *(fails: SyntaxError: from __future__ imports must occur at the beginning of the file, ModuleNotFoundError: No module named 'faiss', RuntimeError: POSTGRES_PASSWORD environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_b_68c4ddb5ca9083289dfc85d4ee618105