### PR TITLE
Add harmonic pattern processor to enrichment pipeline

### DIFF
--- a/core/harmonic_processor.py
+++ b/core/harmonic_processor.py
@@ -1,0 +1,133 @@
+"""Harmonic pattern detection wrapper for enrichment pipeline."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import logging
+import pandas as pd
+
+
+class HarmonicPatternDetector:
+    """Lightweight harmonic pattern detector.
+
+    This class is adapted from ``utils.ncos_enhanced_analyzer`` but strips down
+    the implementation to the essentials required for the enrichment pipeline.
+    """
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self.logger = logger or logging.getLogger(__name__)
+        self.patterns: Dict[str, Dict[str, float]] = {
+            "GARTLEY": {"XA": 0.618, "AB": 0.382, "BC": 0.886, "CD": 0.786},
+            "BUTTERFLY": {"XA": 0.786, "AB": 0.382, "BC": 0.886, "CD": 1.27},
+            "BAT": {"XA": 0.382, "AB": 0.382, "BC": 0.886, "CD": 0.886},
+            "CRAB": {"XA": 0.382, "AB": 0.382, "BC": 0.886, "CD": 1.618},
+            "SHARK": {"XA": 0.5, "AB": 0.5, "BC": 1.618, "CD": 0.886},
+            "CYPHER": {"XA": 0.382, "AB": 0.382, "BC": 1.272, "CD": 0.786},
+            "THREE_DRIVES": {"XA": 0.618, "AB": 0.618, "BC": 0.618, "CD": 0.786},
+            "ABCD": {"AB": 0.618, "BC": 0.618, "CD": 1.272},
+        }
+
+    # --- Detection helpers -------------------------------------------------
+    def detect_patterns(self, df: pd.DataFrame) -> List[Dict[str, Any]]:
+        """Detect all harmonic patterns present in ``df``."""
+        patterns_found: List[Dict[str, Any]] = []
+        try:
+            high = df["high"].values
+            low = df["low"].values
+            close = df["close"].values
+            pivots = self._find_pivots(high, low, close)
+            for name, ratios in self.patterns.items():
+                patterns_found.extend(self._check_pattern(pivots, ratios, name))
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.warning("error detecting harmonic patterns: %s", exc)
+        return patterns_found
+
+    def _find_pivots(self, high, low, close, window: int = 5) -> List[Dict[str, Any]]:
+        pivots: List[Dict[str, Any]] = []
+        for i in range(window, len(high) - window):
+            if all(high[i] >= high[i - j] for j in range(1, window + 1)) and all(
+                high[i] >= high[i + j] for j in range(1, window + 1)
+            ):
+                pivots.append({"index": i, "price": float(high[i]), "type": "high"})
+            if all(low[i] <= low[i - j] for j in range(1, window + 1)) and all(
+                low[i] <= low[i + j] for j in range(1, window + 1)
+            ):
+                pivots.append({"index": i, "price": float(low[i]), "type": "low"})
+        return sorted(pivots, key=lambda x: x["index"])
+
+    def _check_pattern(
+        self, pivots: List[Dict[str, Any]], ratios: Dict[str, float], pattern_name: str
+    ) -> List[Dict[str, Any]]:
+        patterns: List[Dict[str, Any]] = []
+        if len(pivots) < 5:
+            return patterns
+        for i in range(len(pivots) - 4):
+            points = pivots[i : i + 5]
+            if self._validate_pattern_structure(points, ratios):
+                patterns.append(
+                    {
+                        "pattern": pattern_name,
+                        "points": points,
+                        "completion_time": points[-1]["index"],
+                        "completion_price": points[-1]["price"],
+                    }
+                )
+        return patterns
+
+    def _validate_pattern_structure(
+        self, points: List[Dict[str, Any]], ratios: Dict[str, float], tolerance: float = 0.05
+    ) -> bool:
+        try:
+            xa = abs(points[1]["price"] - points[0]["price"])
+            ab = abs(points[2]["price"] - points[1]["price"])
+            bc = abs(points[3]["price"] - points[2]["price"])
+            cd = abs(points[4]["price"] - points[3]["price"])
+            for ratio_name, expected in ratios.items():
+                if ratio_name == "XA":
+                    actual = ab / xa if xa else 0
+                elif ratio_name == "AB":
+                    actual = bc / ab if ab else 0
+                elif ratio_name == "BC":
+                    actual = cd / bc if bc else 0
+                elif ratio_name == "CD":
+                    actual = cd / xa if xa else 0
+                else:
+                    continue
+                if abs(actual - expected) > tolerance:
+                    return False
+            return True
+        except Exception:  # pragma: no cover - defensive
+            return False
+
+
+class HarmonicProcessor:
+    """Encapsulate harmonic pattern detection."""
+
+    def __init__(self, detector: HarmonicPatternDetector | None = None) -> None:
+        self.detector = detector or HarmonicPatternDetector()
+
+    def analyze(self, df: pd.DataFrame) -> Dict[str, Any]:
+        """Return harmonic pattern analysis for ``df``."""
+        raw_patterns = self.detector.detect_patterns(df)
+        processed: List[Dict[str, Any]] = []
+        prz_list: List[Dict[str, Any]] = []
+        confidences: List[float] = []
+        for p in raw_patterns:
+            pts = [{"index": pt["index"], "price": pt["price"]} for pt in p.get("points", [])]
+            prices = [pt["price"] for pt in pts]
+            if prices:
+                prz = {"min": min(prices), "max": max(prices)}
+            else:
+                prz = {"min": None, "max": None}
+            confidence = float(len(pts)) / 5 if pts else 0.0
+            processed.append({"pattern": p.get("pattern"), "points": pts, "prz": prz, "confidence": confidence})
+            prz_list.append(prz)
+            confidences.append(confidence)
+        return {
+            "harmonic_patterns": processed,
+            "prz": prz_list,
+            "confidence": confidences,
+        }
+
+
+__all__ = ["HarmonicProcessor", "HarmonicPatternDetector"]

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -2,6 +2,7 @@
 
 from .payloads import (
     ISPTSPipelineResult,  # ISPTS pipeline stage outputs
+    HarmonicPattern,
     MarketContext,
     MicrostructureAnalysis,
     PredictiveAnalysisResult,
@@ -34,6 +35,7 @@ __all__ = (
     "BehavioralScoreOutput",
     "ConflictDetectionResult",
     "HealthStatus",
+    "HarmonicPattern",
     "ISPTSPipelineResult",
     "MarketContext",
     "MicrostructureAnalysis",

--- a/schemas/payloads.py
+++ b/schemas/payloads.py
@@ -88,6 +88,23 @@ class MicrostructureAnalysis(BaseModel):
         None, description="Order flow toxicity score"
     )
 
+
+class HarmonicPattern(BaseModel):
+    """Detected harmonic pattern information."""
+
+    pattern: str = Field(..., description="Name of the harmonic pattern")
+    points: List[Dict[str, float]] = Field(
+        default_factory=list,
+        description="List of pivot points with index and price",
+    )
+    prz: Dict[str, float] = Field(
+        default_factory=dict,
+        description="Potential reversal zone boundaries",
+    )
+    confidence: float = Field(
+        0.0, description="Confidence score for the pattern",
+    )
+
 class PredictiveAnalysisResult(BaseModel):
     """Aggregated predictive scoring and conflict detection."""
 
@@ -118,6 +135,10 @@ class ISPTSPipelineResult(BaseModel):
     fvg_locator: Any = Field(
         ..., description="FVG locator stage output",
     )
+    harmonic_processor: Any = Field(
+        ..., description="Harmonic processor stage output",
+    )
+
     risk_manager: Any = Field(
         ..., description="Risk manager stage output",
     )

--- a/services/enrichment/ispts_consumer.py
+++ b/services/enrichment/ispts_consumer.py
@@ -244,6 +244,7 @@ def main() -> None:
                     liquidity_engine=state.get("LiquidityEngine", {}),
                     structure_validator=state.get("StructureValidator", {}),
                     fvg_locator=state.get("FVGLocator", {}),
+                    harmonic_processor=state.get("HarmonicProcessor", {}),
                     risk_manager=state.get("RiskManager", {}),
                     confluence_stacker=state.get("ConfluenceStacker", {}),
                 )

--- a/services/enrichment/modules/context_analyzer.py
+++ b/services/enrichment/modules/context_analyzer.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+import pandas as pd
+
 from core.context_analyzer import ContextAnalyzer
 from enrichment.enrichment_engine import run_data_module
 

--- a/services/enrichment/modules/harmonic_processor.py
+++ b/services/enrichment/modules/harmonic_processor.py
@@ -1,0 +1,20 @@
+"""Detect harmonic price patterns using :class:`core.harmonic_processor.HarmonicProcessor`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from core.harmonic_processor import HarmonicProcessor
+from enrichment.enrichment_engine import run_data_module
+
+
+def run(state: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+    """Populate ``state`` with harmonic pattern analysis."""
+    return run_data_module(
+        state,
+        required_cols=("open", "high", "low", "close"),
+        engine_factory=lambda: HarmonicProcessor(**config),
+    )
+
+
+__all__ = ["run"]

--- a/services/enrichment/pipeline.py
+++ b/services/enrichment/pipeline.py
@@ -8,10 +8,12 @@ an exception is raised.
 
 Order of execution:
     1. structure_validator
-    2. liquidity_engine
-    3. context_analyzer
-    4. fvg_locator
-    5. predictive_scorer
+    2. technical_indicators
+    3. liquidity_engine
+    4. context_analyzer
+    5. fvg_locator
+    6. harmonic_processor
+    7. predictive_scorer
 """
 
 from __future__ import annotations
@@ -27,6 +29,7 @@ MODULE_ORDER: Iterable[str] = (
     "liquidity_engine",
     "context_analyzer",
     "fvg_locator",
+    "harmonic_processor",
     "predictive_scorer",
 )
 

--- a/tests/services/enrichment/test_handler_discord_alert.py
+++ b/tests/services/enrichment/test_handler_discord_alert.py
@@ -71,6 +71,7 @@ def _build_payload(score: float) -> UnifiedAnalysisPayloadV1:
             liquidity_engine={},
             structure_validator={},
             fvg_locator={},
+            harmonic_processor={},
             risk_manager={},
             confluence_stacker={},
         ),

--- a/tests/services/enrichment/test_ispts_consumer.py
+++ b/tests/services/enrichment/test_ispts_consumer.py
@@ -30,6 +30,7 @@ class ISPTSPipelineResult(BaseModel):
     liquidity_engine: dict = {}
     structure_validator: dict = {}
     fvg_locator: dict = {}
+    harmonic_processor: dict = {}
     risk_manager: dict = {}
     confluence_stacker: dict = {}
 

--- a/tests/test_enrichment_config.py
+++ b/tests/test_enrichment_config.py
@@ -13,10 +13,11 @@ class DummyPredictiveScorer:
 def _import_analysis_engines():
     """Import ``utils.analysis_engines`` with core scorer stubbed."""
     core_pkg = ModuleType("core")
-    sys.modules.setdefault("core", core_pkg)
+    sys.modules["core"] = core_pkg
     cps = ModuleType("core.predictive_scorer")
     cps.PredictiveScorer = DummyPredictiveScorer
     sys.modules["core.predictive_scorer"] = cps
+    sys.modules.pop("utils.analysis_engines", None)
     return importlib.import_module("utils.analysis_engines")
 
 

--- a/tests/test_enrichment_pipeline.py
+++ b/tests/test_enrichment_pipeline.py
@@ -38,6 +38,9 @@ def test_pipeline_runs_all(monkeypatch) -> None:
     assert "liquidity_zones" in state
     assert "wyckoff_analysis" in state
     assert "maturity_score" in state
+    assert "harmonic_patterns" in state
+    assert "prz" in state
+    assert "confidence" in state
 
 
 def test_pipeline_stops_on_failure(monkeypatch) -> None:

--- a/utils/analysis_engines.py
+++ b/utils/analysis_engines.py
@@ -70,6 +70,7 @@ def build_unified_analysis(
         liquidity_engine={},
         structure_validator={},
         fvg_locator={},
+        harmonic_processor={},
         risk_manager={},
         confluence_stacker={},
     )


### PR DESCRIPTION
## Summary
- implement HarmonicProcessor engine for detecting harmonic price patterns
- expose harmonic_processor enrichment module and wire into pipeline
- extend payload schemas with HarmonicPattern model and pipeline output

## Testing
- `pytest tests/test_enrichment_pipeline.py tests/services/enrichment/test_handler_discord_alert.py tests/test_enrichment_config.py -q`
- `pytest tests/services/enrichment/test_ispts_consumer.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4dc8a3468832896c7c0c75177acf3