### PR TITLE
Expose HarmonicProcessor in processors package

### DIFF
--- a/utils/processors/__init__.py
+++ b/utils/processors/__init__.py
@@ -1,4 +1,5 @@
 from .advanced import AdvancedProcessor, RLAgent
 from .structure import StructureProcessor
+from .harmonic import HarmonicProcessor
 
-__all__ = ["AdvancedProcessor", "StructureProcessor", "RLAgent"]
+__all__ = ["AdvancedProcessor", "StructureProcessor", "RLAgent", "HarmonicProcessor"]


### PR DESCRIPTION
## Summary
- expose HarmonicProcessor through `utils.processors` package

## Testing
- `pre-commit run --files utils/processors/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyarrow'; RuntimeError: POSTGRES_PASSWORD environment variable is required, and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c4dff0f4f483289ecf822d267bd0f0