### PR TITLE
Add harmonic pattern support to unified analysis

### DIFF
--- a/schemas/payloads.py
+++ b/schemas/payloads.py
@@ -88,6 +88,22 @@ class MicrostructureAnalysis(BaseModel):
         None, description="Order flow toxicity score"
     )
 
+
+class HarmonicResult(BaseModel):
+    """Results from harmonic pattern detection."""
+
+    harmonic_patterns: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="List of detected harmonic patterns",
+    )
+    prz: Any = Field(
+        None, description="Potential reversal zone for the detected pattern(s)"
+    )
+    confidence: Optional[float] = Field(
+        None, description="Confidence score of the detected harmonic pattern(s)"
+    )
+
+
 class PredictiveAnalysisResult(BaseModel):
     """Aggregated predictive scoring and conflict detection."""
 
@@ -124,6 +140,10 @@ class ISPTSPipelineResult(BaseModel):
     confluence_stacker: Any = Field(
         ..., description="Confluence stacker stage output",
     )
+    harmonic: HarmonicResult = Field(
+        default_factory=HarmonicResult,
+        description="Harmonic pattern detection results",
+    )
 
 
 class UnifiedAnalysisPayloadV1(BaseModel):
@@ -149,9 +169,12 @@ class UnifiedAnalysisPayloadV1(BaseModel):
     microstructure: MicrostructureAnalysis = Field(
         ..., description="Order flow and microstructure metrics"
     )
+    harmonic: HarmonicResult = Field(
+        default_factory=HarmonicResult,
+        description="Harmonic pattern detection results",
+    )
     predictive_analysis: PredictiveAnalysisResult = Field(
         ..., description="Aggregated predictive scoring and conflict detection results",
-
     )
     ispts_pipeline: ISPTSPipelineResult = Field(
         ..., description="Outputs from each stage of the ISPTS pipeline",

--- a/services/enrichment/handler.py
+++ b/services/enrichment/handler.py
@@ -42,7 +42,7 @@ def on_message(ctx: Dict[str, Any], msg: Message) -> None:
                 "payload_id": str(uuid.uuid4()),
             }
             ctx["redis"].publish("discord-alerts", json.dumps(alert))
-        serialized = payload.model_dump_json().encode("utf-8")
+        serialized = payload.model_dump_json(exclude_none=False).encode("utf-8")
         ctx["producer"].produce("enriched-analysis-payloads", value=serialized)
         decision = "produced_payload"
     except Exception as e:  # pragma: no cover - log and continue

--- a/services/enrichment/worker.py
+++ b/services/enrichment/worker.py
@@ -52,7 +52,7 @@ async def main() -> None:
                     tick = json.loads(fields["j"])
                     try:
                         payload = build_unified_analysis(tick)
-                        enriched_json = payload.model_dump()
+                        enriched_json = payload.model_dump(exclude_none=False)
                     except Exception as e:  # pragma: no cover - defensive
                         enriched_json = {"error": str(e)}
 

--- a/tests/test_harmonic_unified_analysis.py
+++ b/tests/test_harmonic_unified_analysis.py
@@ -1,0 +1,40 @@
+import importlib
+import sys
+from types import ModuleType
+
+from utils.enrichment_config import EnrichmentConfig
+
+
+class DummyPredictiveScorer:
+    def score(self, state):  # pragma: no cover - simple stub
+        return {"maturity_score": 0.0}
+
+
+def _import_analysis_engines():
+    core_pkg = ModuleType("core")
+    sys.modules.setdefault("core", core_pkg)
+    cps = ModuleType("core.predictive_scorer")
+    cps.PredictiveScorer = DummyPredictiveScorer
+    sys.modules["core.predictive_scorer"] = cps
+    return importlib.import_module("utils.analysis_engines")
+
+
+def test_build_unified_analysis_includes_harmonic():
+    ae = _import_analysis_engines()
+    cfg = EnrichmentConfig()
+    for grp in cfg.technical.groups.values():
+        grp.enabled = False
+    tick = {
+        "symbol": "EURUSD",
+        "timestamp": 0,
+        "harmonic": {
+            "harmonic_patterns": [{"pattern": "bat"}],
+            "prz": {"low": 1.0, "high": 1.2},
+            "confidence": 0.9,
+        },
+    }
+    payload = ae.build_unified_analysis(tick, cfg)
+    harmonic = payload.harmonic
+    assert harmonic.harmonic_patterns[0]["pattern"] == "bat"
+    assert harmonic.prz == {"low": 1.0, "high": 1.2}
+    assert harmonic.confidence == 0.9


### PR DESCRIPTION
## Summary
- add `HarmonicResult` schema and integrate harmonic results into unified analysis and pipeline payloads
- include harmonic data when serializing enrichment handler and worker payloads
- cover harmonic pattern serialization with unit test

## Testing
- `pytest tests/test_harmonic_unified_analysis.py tests/test_enrichment_config.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68c4e078582c8328b18ebdc309e84b81