### PR TITLE
Validate essential enrichment config options

### DIFF
--- a/config/enrichment_default.yaml
+++ b/config/enrichment_default.yaml
@@ -28,8 +28,17 @@ advanced:
   predictive_scorer: true
   fractal_detector: true
   fractal_bars: 2
+  harmonic:
+    enabled: true
+    collection: harmonic_patterns
   alligator:
     enabled: true
     jaw: 13
     teeth: 8
     lips: 5
+
+vector_db:
+  collection: enrichment_vectors
+
+embedding:
+  model: text-embedding-3-small


### PR DESCRIPTION
## Summary
- extend enrichment config to include harmonic, vector DB, and embedding model sections
- check for required vector_db.collection, advanced.harmonic, and embedding.model options when loading config
- add tests for missing enrichment settings

## Testing
- `pre-commit run --files utils/enrichment_config.py config/enrichment_default.yaml tests/test_enrichment_config.py` *(fails: command not found: pre-commit)*
- `pytest` *(fails: 33 errors during collection)*
- `pytest tests/test_enrichment_config.py`


------
https://chatgpt.com/codex/tasks/task_b_68c4e1f9e24c832893c16290d90041e9