### PR TITLE
Add microstructure filter and integrate into analytics

### DIFF
--- a/core/microstructure_filter.py
+++ b/core/microstructure_filter.py
@@ -1,0 +1,51 @@
+"""Basic microstructure data filtering utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def apply_microstructure_filter(
+    df: pd.DataFrame, *, max_spread: float | None = None
+) -> pd.DataFrame:
+    """Remove ticks that violate simple market microstructure rules.
+
+    The filter guards against corrupt or unrealistic tick data by applying the
+    following rules:
+
+    1. ``bid`` must be strictly less than ``ask`` when both are available.
+    2. Optional ``max_spread`` can cap the allowed bid/ask spread.
+    3. If a volume column (``inferred_volume``/``volume``/``tickvol``) exists it
+       must be positive.
+
+    Parameters
+    ----------
+    df:
+        Input tick dataframe.
+    max_spread:
+        Maximum allowed spread. Rows exceeding this threshold are dropped. If
+        ``None`` the check is skipped.
+
+    Returns
+    -------
+    pd.DataFrame
+        Filtered dataframe with the same columns as the input.
+    """
+
+    if df.empty:
+        return df
+
+    filtered = df.copy()
+
+    if {"bid", "ask"}.issubset(filtered.columns):
+        filtered = filtered[filtered["bid"] < filtered["ask"]]
+        filtered = filtered.assign(spread=(filtered["ask"] - filtered["bid"]).abs())
+        if max_spread is not None:
+            filtered = filtered[filtered["spread"] <= max_spread]
+
+    for col in ("inferred_volume", "volume", "tickvol"):
+        if col in filtered.columns:
+            filtered = filtered[filtered[col] > 0]
+            break
+
+    return filtered.reset_index(drop=True)

--- a/tests/core/test_microstructure_filter.py
+++ b/tests/core/test_microstructure_filter.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from core.microstructure_filter import apply_microstructure_filter
+
+
+def test_apply_microstructure_filter_removes_invalid_ticks():
+    df = pd.DataFrame(
+        {
+            "bid": [100.0, 100.5, 101.0, 100.2],
+            "ask": [100.1, 100.4, 100.9, 100.7],
+            "volume": [10, 0, 5, 8],
+        }
+    )
+
+    filtered = apply_microstructure_filter(df, max_spread=0.3)
+
+    assert len(filtered) == 1
+    assert filtered.iloc[0]["bid"] == 100.0
+    assert filtered.iloc[0]["ask"] == 100.1


### PR DESCRIPTION
## Summary
- implement `apply_microstructure_filter` utility with basic bid/ask spread and volume checks
- import and invoke microstructure filter within tick analytics dashboard
- add unit test verifying invalid ticks are dropped

## Testing
- `pre-commit run --files core/microstructure_filter.py tests/core/test_microstructure_filter.py`
- `pre-commit run --files "dashboard/_mix/29_  🔎 Tick manipulation insights copy.py"` *(fails: Cannot parse: 2082:8)*
- `pytest tests/core/test_microstructure_filter.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4e2f2efb08328865d0c22563cd1ed