### PR TITLE
Add basic Wyckoff event detectors with tests

### DIFF
--- a/dashboard/_mix/5_  🧠 SMC & WYCKOFF.py
+++ b/dashboard/_mix/5_  🧠 SMC & WYCKOFF.py
@@ -1,3 +1,18 @@
+"""QRT dashboard blending smart-money concepts with Wyckoff analysis.
+
+This module powers an interactive Streamlit dashboard.  The analytical core
+includes lightweight detectors for several Wyckoff events used throughout the
+app and exposed here for unit testing:
+
+* **Selling climax** – identifies a sharp downward move on extreme volume.
+* **Accumulation range** – detects a period of reduced volatility and volume.
+* **Spring** – finds a temporary break below support that quickly reverses.
+* **Markup beginning** – flags a breakout above resistance with volume
+  expansion.
+
+The detectors are intentionally simple and serve as placeholders for more
+advanced implementations.
+"""
 
 import streamlit as st
 
@@ -451,20 +466,56 @@ class QRTQuantumAnalyzer(QuantumMicrostructureAnalyzer):
                 "delta_div": bullish_div + bearish_div}
 
     def _detect_selling_climax(self, df):
-        # TODO: Replace with real selling climax detection logic
-        return False
+        """Basic selling climax detection.
+
+        Returns ``True`` when the last bar prints a new low accompanied by a
+        volume spike and a sharp percentage drop from the start of ``df``.
+        ``df`` must contain ``close``, ``low`` and ``volume`` columns.
+        """
+        required = {"close", "low", "volume"}
+        if not required.issubset(df.columns) or len(df) < 5:
+            return False
+        last = df.iloc[-1]
+        if last["low"] > df["low"].min():
+            return False
+        volume_spike = last["volume"] >= df["volume"].mean() * 2
+        drop = (last["close"] - df["close"].iloc[0]) / df["close"].iloc[0]
+        return volume_spike and drop <= -0.03
 
     def _detect_accumulation_range(self, df):
-        # TODO: Replace with real accumulation range detection logic
-        return False
+        """Detect a low-volatility, low-volume accumulation range."""
+        required = {"high", "low", "volume"}
+        lookback = min(20, len(df))
+        if not required.issubset(df.columns) or lookback < 2:
+            return False
+        recent = df.tail(lookback)
+        recent_range = recent["high"].max() - recent["low"].min()
+        full_range = df["high"].max() - df["low"].min()
+        volume_drop = recent["volume"].mean() < df["volume"].mean()
+        return full_range > 0 and recent_range / full_range < 0.4 and volume_drop
 
     def _detect_spring(self, df):
-        # TODO: Replace with real spring detection logic
+        """Detect a spring: price dips below support then closes back above."""
+        required = {"low", "close"}
+        if not required.issubset(df.columns) or len(df) < 2:
+            return None
+        for i in range(1, len(df)):
+            support = df["low"].iloc[:i].min()
+            bar = df.iloc[i]
+            if bar["low"] < support and bar["close"] > support:
+                return i
         return None
 
     def _detect_markup_beginning(self, df):
-        # TODO: Replace with real markup beginning detection logic
-        return False
+        """Detect the start of a markup phase via breakout and volume spike."""
+        required = {"high", "close", "volume"}
+        if not required.issubset(df.columns) or len(df) < 2:
+            return False
+        resistance = df["high"].iloc[:-1].max()
+        last = df.iloc[-1]
+        breakout = last["close"] > resistance
+        volume_spike = last["volume"] > df["volume"].iloc[:-1].mean() * 1.5
+        return breakout and volume_spike
 
 
 class TiquidityEngine:

--- a/tests/test_wyckoff_dashboard_detection.py
+++ b/tests/test_wyckoff_dashboard_detection.py
@@ -1,0 +1,83 @@
+import ast
+from pathlib import Path
+import pandas as pd
+import numpy as np
+from typing import Dict, Optional
+
+
+def load_analyzer():
+    """Extract QRTQuantumAnalyzer class without executing dashboard code."""
+    root = Path(__file__).resolve().parents[1]
+    path = root / "dashboard" / "_mix" / "5_  🧠 SMC & WYCKOFF.py"
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    class_node = next(
+        node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "QRTQuantumAnalyzer"
+    )
+    module = ast.Module(body=[class_node], type_ignores=[])
+    code = compile(module, str(path), "exec")
+    class QuantumMicrostructureAnalyzer:
+        def __init__(self, config_path=None):
+            pass
+
+    namespace = {
+        "pd": pd,
+        "np": np,
+        "Dict": Dict,
+        "Optional": Optional,
+        "QuantumMicrostructureAnalyzer": QuantumMicrostructureAnalyzer,
+        "TiquidityEngine": type("TiquidityEngine", (), {}),
+        "WyckoffQuantumAnalyzer": type("WyckoffQuantumAnalyzer", (), {}),
+    }
+    exec(code, namespace)
+    return namespace["QRTQuantumAnalyzer"]
+
+
+QRTAnalyzer = load_analyzer()
+
+
+def test_detect_selling_climax():
+    analyzer = QRTAnalyzer(None)
+    df = pd.DataFrame({
+        "close": [10, 9.5, 9.0, 8.5, 7.0],
+        "low": [9.8, 9.3, 8.8, 8.0, 6.8],
+        "high": [10.2, 9.7, 9.3, 9.0, 7.5],
+        "volume": [100, 110, 120, 130, 400]
+    })
+    assert analyzer._detect_selling_climax(df)
+
+
+def test_detect_accumulation_range():
+    analyzer = QRTAnalyzer(None)
+    trend_prices = pd.Series(np.linspace(30, 20, 10))
+    prices1 = pd.Series([10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
+    prices2 = pd.Series([1.1, 1.2, 1.15, 1.18, 1.12, 1.14, 1.13, 1.16, 1.15, 1.17])
+    df = pd.DataFrame({
+        "close": pd.concat([trend_prices, prices1, prices2], ignore_index=True),
+        "high": pd.concat([trend_prices + 0.2, prices1 + 0.2, prices2 + 0.1], ignore_index=True),
+        "low": pd.concat([trend_prices - 0.2, prices1 - 0.2, prices2 - 0.1], ignore_index=True),
+        "volume": [300]*10 + [200]*10 + [50]*10
+    })
+    assert analyzer._detect_accumulation_range(df)
+
+
+def test_detect_spring():
+    analyzer = QRTAnalyzer(None)
+    df = pd.DataFrame({
+        "close": [10, 10.1, 10.2, 10.15, 10.0],
+        "high": [10.2, 10.3, 10.25, 10.2, 10.1],
+        "low": [9.8, 9.9, 9.85, 9.8, 9.4]
+    })
+    spring_idx = analyzer._detect_spring(df)
+    assert spring_idx == len(df) - 1
+
+
+def test_detect_markup_beginning():
+    analyzer = QRTAnalyzer(None)
+    df = pd.DataFrame({
+        "close": [10, 10.1, 10.2, 10.15, 10.5],
+        "high": [10.2, 10.3, 10.25, 10.2, 10.6],
+        "low": [9.9, 10.0, 10.1, 9.95, 10.3],
+        "volume": [100, 100, 100, 100, 300]
+    })
+    assert analyzer._detect_markup_beginning(df)


### PR DESCRIPTION
## Summary
- implement simple selling climax, accumulation range, spring, and markup detectors in SMC & Wyckoff dashboard
- document detection logic in dashboard module
- add unit tests for each detector

## Testing
- `pytest tests/test_wyckoff_dashboard_detection.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4e2ee77488328936c54b8ebc9d866