### PR TITLE
Rename HarmonicProcessor helper to HarmonicVectorStore

### DIFF
--- a/docs/harmonic_patterns.md
+++ b/docs/harmonic_patterns.md
@@ -53,7 +53,8 @@ scaling linearly with input size.
 
 ```python
 import pandas as pd
-from utils.processors import AdvancedProcessor, HarmonicProcessor
+from utils.processors import AdvancedProcessor
+from core.harmonic_processor import HarmonicProcessor
 
 # Minimal OHLC sample; use real market data in practice
 bars = pd.DataFrame({

--- a/tests/test_harmonic_vector_store.py
+++ b/tests/test_harmonic_vector_store.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils.processors.harmonic import HarmonicProcessor
+from utils.processors.harmonic import HarmonicVectorStore
 
 
 class DummySyncClient:
@@ -22,14 +22,14 @@ class DummyAsyncClient:
 @pytest.mark.asyncio
 async def test_upsert_uses_background_thread_for_sync_client():
     client = DummySyncClient()
-    proc = HarmonicProcessor(client)
-    await proc.upsert([[0.1]], [{}], [1])
+    store = HarmonicVectorStore(client)
+    await store.upsert([[0.1]], [{}], [1])
     assert client.called
 
 
 @pytest.mark.asyncio
 async def test_upsert_awaits_async_client():
     client = DummyAsyncClient()
-    proc = HarmonicProcessor(client)
-    await proc.upsert([[0.1]], [{}], [1])
+    store = HarmonicVectorStore(client)
+    await store.upsert([[0.1]], [{}], [1])
     assert client.called

--- a/utils/processors/__init__.py
+++ b/utils/processors/__init__.py
@@ -1,5 +1,5 @@
 from .advanced import AdvancedProcessor, RLAgent
 from .structure import StructureProcessor
-from .harmonic import HarmonicProcessor
+from .harmonic import HarmonicVectorStore
 
-__all__ = ["AdvancedProcessor", "StructureProcessor", "RLAgent", "HarmonicProcessor"]
+__all__ = ["AdvancedProcessor", "StructureProcessor", "RLAgent", "HarmonicVectorStore"]

--- a/utils/processors/harmonic.py
+++ b/utils/processors/harmonic.py
@@ -1,9 +1,8 @@
-
 """Harmonic pattern utilities with asynchronous Qdrant insertion.
 
-This module exposes :class:`HarmonicProcessor` which mirrors the style of
-other processors under :mod:`utils.processors`. The processor accepts either
-an :class:`qdrant_client.AsyncQdrantClient` or the traditional synchronous
+This module exposes :class:`HarmonicVectorStore` which mirrors the style of
+other processors under :mod:`utils.processors`. The store accepts either an
+:class:`qdrant_client.AsyncQdrantClient` or the traditional synchronous
 :class:`qdrant_client.QdrantClient`. Inserts are executed in a non-blocking
 fashion: asynchronous clients are awaited directly while synchronous clients
 are dispatched to a background thread using :func:`asyncio.to_thread`.
@@ -21,7 +20,7 @@ from typing import Iterable, Sequence
 from qdrant_client import models
 
 
-class HarmonicProcessor:
+class HarmonicVectorStore:
     """Processor responsible for persisting harmonic pattern vectors."""
 
     def __init__(self, client: object, collection_name: str = "harmonic") -> None:
@@ -68,5 +67,4 @@ class HarmonicProcessor:
             )
 
 
-__all__ = ["HarmonicProcessor"]
-
+__all__ = ["HarmonicVectorStore"]


### PR DESCRIPTION
## Summary
- rename `HarmonicProcessor` in utils to `HarmonicVectorStore`
- update processor package exports and docs
- adjust unit tests for new class name

## Testing
- `pre-commit run --files utils/processors/harmonic.py utils/processors/__init__.py tests/test_harmonic_vector_store.py docs/harmonic_patterns.md`
- `pytest tests/test_harmonic_vector_store.py -q`
- `pytest tests/test_harmonic_vector_store.py tests/test_advanced_processor.py` *(fails: assert mismatch in `tests/test_advanced_processor.py` and LLM mock not called)*

------
https://chatgpt.com/codex/tasks/task_b_68c4e46829e08328abf19614381bb9c7