### PR TITLE
Support string IDs in vector utilities

### DIFF
--- a/analytics/vector_db_config.py
+++ b/analytics/vector_db_config.py
@@ -18,12 +18,27 @@ import faiss
 VECTOR_DIMENSION = int(os.getenv("VECTOR_DIMENSION", "1536"))
 
 _faiss_index = faiss.IndexFlatL2(VECTOR_DIMENSION)
-_faiss_ids: List[str] = []
-_faiss_metadata: Dict[str, Dict] = {}
+_faiss_ids: List[str | int] = []
+_faiss_metadata: Dict[str | int, Dict] = {}
 
 
-def add_vectors(vectors: Iterable[Iterable[float]], ids: Iterable[str], metadata: Optional[Iterable[Dict]] = None) -> None:
-    """Add vectors with associated ids and metadata to the configured store."""
+def add_vectors(
+    vectors: Iterable[Iterable[float]],
+    ids: Iterable[str | int],
+    metadata: Optional[Iterable[Dict]] = None,
+) -> None:
+    """Add vectors with associated ids and metadata to the configured store.
+
+    Parameters
+    ----------
+    vectors:
+        Iterable of vector embeddings.
+    ids:
+        Globally unique identifiers for each vector. Values may be strings or
+        integers. IDs must be globally unique across the entire index.
+    metadata:
+        Optional iterable of dictionaries containing per-vector metadata.
+    """
     if metadata is None:
         metadata = [{} for _ in ids]
     vec_array = np.array(list(vectors), dtype="float32")
@@ -44,7 +59,9 @@ def query_vector(vector: Iterable[float], top_k: int = 5) -> List[Dict]:
         if idx == -1:
             continue
         id_ = _faiss_ids[idx]
-        matches.append({"id": id_, "score": float(dist), "metadata": _faiss_metadata.get(id_)})
+        matches.append(
+            {"id": id_, "score": float(dist), "metadata": _faiss_metadata.get(id_)}
+        )
     return matches
 
 

--- a/tests/test_vector_db_config.py
+++ b/tests/test_vector_db_config.py
@@ -1,5 +1,34 @@
 import importlib
 import sys
+import types
+import numpy as np
+
+
+class FakeIndexFlatL2:
+    def __init__(self, dimension: int):
+        self.dimension = dimension
+        self.vectors: list[np.ndarray] = []
+
+    def add(self, vec_array: np.ndarray) -> None:
+        for vec in vec_array:
+            self.vectors.append(vec)
+
+    def search(self, vec: np.ndarray, top_k: int):
+        if not self.vectors:
+            return np.array([[]], dtype="float32"), np.array([[]], dtype="int64")
+        arr = np.stack(self.vectors)
+        dists = np.sum((arr - vec) ** 2, axis=1)
+        idxs = np.argsort(dists)[:top_k]
+        return np.array([dists[idxs]], dtype="float32"), np.array([idxs], dtype="int64")
+
+    @property
+    def ntotal(self) -> int:
+        return len(self.vectors)
+
+
+faiss_stub = types.ModuleType("faiss")
+faiss_stub.IndexFlatL2 = FakeIndexFlatL2
+sys.modules.setdefault("faiss", faiss_stub)
 
 
 def _reload_module(monkeypatch, env):
@@ -11,11 +40,12 @@ def _reload_module(monkeypatch, env):
     if "analytics.vector_db_config" in sys.modules:
         del sys.modules["analytics.vector_db_config"]
     import analytics.vector_db_config as cfg
+
     return importlib.reload(cfg)
 
 
 def test_faiss_storage(monkeypatch):
     cfg = _reload_module(monkeypatch, {"VECTOR_DIMENSION": "3"})
-    cfg.add_vectors([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], ["a", "b"])
+    cfg.add_vectors([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], [101, "b"])
     res = cfg.query_vector([1.0, 0.0, 0.0], top_k=1)
-    assert res and res[0]["id"] == "a"
+    assert res and res[0]["id"] == 101

--- a/utils/processors/harmonic.py
+++ b/utils/processors/harmonic.py
@@ -1,4 +1,3 @@
-
 """Harmonic pattern utilities with asynchronous Qdrant insertion.
 
 This module exposes :class:`HarmonicProcessor` which mirrors the style of
@@ -44,7 +43,7 @@ class HarmonicProcessor:
         self,
         vectors: Sequence[Sequence[float]],
         payloads: Iterable[dict],
-        ids: Iterable[int],
+        ids: Iterable[str | int],
     ) -> None:
         """Insert vectors into Qdrant asynchronously.
 
@@ -52,6 +51,9 @@ class HarmonicProcessor:
         client. Synchronous clients are executed in a background thread via
         :func:`asyncio.to_thread`, mirroring patterns used in other asynchronous
         utilities.
+
+        ``ids`` are expected to be globally unique within the collection and
+        may be provided as either strings or integers.
         """
 
         points = [
@@ -69,4 +71,3 @@ class HarmonicProcessor:
 
 
 __all__ = ["HarmonicProcessor"]
-


### PR DESCRIPTION
## Summary
- allow `Iterable[str | int]` IDs for `add_vectors` and `HarmonicProcessor.upsert`
- document expectation of globally unique IDs
- expand tests to cover mixed string/int identifiers

## Testing
- `pre-commit run --files analytics/vector_db_config.py utils/processors/harmonic.py tests/test_vector_db_config.py tests/test_harmonic_processor.py`
- `pytest tests/test_vector_db_config.py tests/test_harmonic_processor.py`

------
https://chatgpt.com/codex/tasks/task_b_68c4e46d32b48328a00cfaafb517044f