### PR TITLE
Add harmonic enrichment config and loader support

### DIFF
--- a/config/enrichment_harmonic.yaml
+++ b/config/enrichment_harmonic.yaml
@@ -1,0 +1,15 @@
+# Harmonic-focused enrichment configuration.
+# Enables harmonic pattern detection with vector database persistence.
+
+advanced:
+  harmonic:
+    enabled: true
+    tolerance: 0.05        # Ratio matching tolerance
+    window: 5              # Pivot look-back window
+    collection: harmonic_patterns
+
+vector_db:
+  collection: harmonic_patterns
+
+embedding:
+  model: text-embedding-3-small

--- a/core/harmonic_processor.py
+++ b/core/harmonic_processor.py
@@ -14,8 +14,16 @@ class HarmonicPatternDetector:
     the implementation to the essentials required for the enrichment pipeline.
     """
 
-    def __init__(self, logger: logging.Logger | None = None) -> None:
+    def __init__(
+        self,
+        logger: logging.Logger | None = None,
+        *,
+        tolerance: float = 0.05,
+        window: int = 5,
+    ) -> None:
         self.logger = logger or logging.getLogger(__name__)
+        self.tolerance = tolerance
+        self.window = window
         self.patterns: Dict[str, Dict[str, float]] = {
             "GARTLEY": {"XA": 0.618, "AB": 0.382, "BC": 0.886, "CD": 0.786},
             "BUTTERFLY": {"XA": 0.786, "AB": 0.382, "BC": 0.886, "CD": 1.27},
@@ -35,14 +43,16 @@ class HarmonicPatternDetector:
             high = df["high"].values
             low = df["low"].values
             close = df["close"].values
-            pivots = self._find_pivots(high, low, close)
+            pivots = self._find_pivots(high, low, close, self.window)
             for name, ratios in self.patterns.items():
-                patterns_found.extend(self._check_pattern(pivots, ratios, name))
+                patterns_found.extend(
+                    self._check_pattern(pivots, ratios, name, self.tolerance)
+                )
         except Exception as exc:  # pragma: no cover - defensive
             self.logger.warning("error detecting harmonic patterns: %s", exc)
         return patterns_found
 
-    def _find_pivots(self, high, low, close, window: int = 5) -> List[Dict[str, Any]]:
+    def _find_pivots(self, high, low, close, window: int) -> List[Dict[str, Any]]:
         pivots: List[Dict[str, Any]] = []
         for i in range(window, len(high) - window):
             if all(high[i] >= high[i - j] for j in range(1, window + 1)) and all(
@@ -56,14 +66,18 @@ class HarmonicPatternDetector:
         return sorted(pivots, key=lambda x: x["index"])
 
     def _check_pattern(
-        self, pivots: List[Dict[str, Any]], ratios: Dict[str, float], pattern_name: str
+        self,
+        pivots: List[Dict[str, Any]],
+        ratios: Dict[str, float],
+        pattern_name: str,
+        tolerance: float,
     ) -> List[Dict[str, Any]]:
         patterns: List[Dict[str, Any]] = []
         if len(pivots) < 5:
             return patterns
         for i in range(len(pivots) - 4):
             points = pivots[i : i + 5]
-            if self._validate_pattern_structure(points, ratios):
+            if self._validate_pattern_structure(points, ratios, tolerance):
                 patterns.append(
                     {
                         "pattern": pattern_name,
@@ -75,7 +89,7 @@ class HarmonicPatternDetector:
         return patterns
 
     def _validate_pattern_structure(
-        self, points: List[Dict[str, Any]], ratios: Dict[str, float], tolerance: float = 0.05
+        self, points: List[Dict[str, Any]], ratios: Dict[str, float], tolerance: float
     ) -> bool:
         try:
             xa = abs(points[1]["price"] - points[0]["price"])
@@ -103,8 +117,16 @@ class HarmonicPatternDetector:
 class HarmonicProcessor:
     """Encapsulate harmonic pattern detection."""
 
-    def __init__(self, detector: HarmonicPatternDetector | None = None) -> None:
-        self.detector = detector or HarmonicPatternDetector()
+    def __init__(
+        self,
+        detector: HarmonicPatternDetector | None = None,
+        *,
+        tolerance: float = 0.05,
+        window: int = 5,
+    ) -> None:
+        self.detector = detector or HarmonicPatternDetector(
+            tolerance=tolerance, window=window
+        )
 
     def analyze(self, df: pd.DataFrame) -> Dict[str, Any]:
         """Return harmonic pattern analysis for ``df``."""
@@ -113,14 +135,24 @@ class HarmonicProcessor:
         prz_list: List[Dict[str, Any]] = []
         confidences: List[float] = []
         for p in raw_patterns:
-            pts = [{"index": pt["index"], "price": pt["price"]} for pt in p.get("points", [])]
+            pts = [
+                {"index": pt["index"], "price": pt["price"]}
+                for pt in p.get("points", [])
+            ]
             prices = [pt["price"] for pt in pts]
             if prices:
                 prz = {"min": min(prices), "max": max(prices)}
             else:
                 prz = {"min": None, "max": None}
             confidence = float(len(pts)) / 5 if pts else 0.0
-            processed.append({"pattern": p.get("pattern"), "points": pts, "prz": prz, "confidence": confidence})
+            processed.append(
+                {
+                    "pattern": p.get("pattern"),
+                    "points": pts,
+                    "prz": prz,
+                    "confidence": confidence,
+                }
+            )
             prz_list.append(prz)
             confidences.append(confidence)
         return {

--- a/docs/enrichment_engine.md
+++ b/docs/enrichment_engine.md
@@ -50,6 +50,12 @@ advanced:
   predictive_scorer: true
 ```
 
+For harmonic pattern detection with vector database persistence, a dedicated
+configuration is provided at
+[`config/enrichment_harmonic.yaml`](../config/enrichment_harmonic.yaml).  It
+defines the harmonic tolerance and pivot window along with the target
+embedding model and collection name.
+
 ### Pydantic configuration model
 
 The groups are represented by the Pydantic
@@ -65,6 +71,9 @@ cfg.technical.groups["trend"].indicators["ema"] = True  # enable EMA on the fly
 
 # Translate grouped toggles into per-module configs
 module_cfg = cfg.to_module_configs()
+
+# Load harmonic-focused configuration
+harmonic_cfg = load_enrichment_config("config/enrichment_harmonic.yaml")
 ```
 
 ### Dynamic configuration API

--- a/services/enrichment/main.py
+++ b/services/enrichment/main.py
@@ -17,8 +17,10 @@ def main(
     """Execute the enrichment pipeline and return its final state.
 
     Configuration is loaded from ``config_path`` and validated using
-    :class:`~utils.enrichment_config.EnrichmentConfig`.  Any configs passed
-    explicitly will override the defaults.
+    :class:`~utils.enrichment_config.EnrichmentConfig`.  To enable harmonic
+    pattern enrichment with vector database persistence, pass
+    ``config/enrichment_harmonic.yaml``.  Any configs passed explicitly will
+    override the defaults.
     """
 
     base_cfg = load_enrichment_config(config_path).to_module_configs()

--- a/utils/enrichment_config.py
+++ b/utils/enrichment_config.py
@@ -54,7 +54,9 @@ def _default_technical_groups() -> Dict[str, TechnicalSubGroup]:
 class TechnicalConfig(BaseModel):
     """Configuration for technical indicator groups."""
 
-    groups: Dict[str, TechnicalSubGroup] = Field(default_factory=_default_technical_groups)
+    groups: Dict[str, TechnicalSubGroup] = Field(
+        default_factory=_default_technical_groups
+    )
 
     @field_validator("groups", mode="before")
     @classmethod
@@ -107,6 +109,14 @@ class HarmonicConfig(BaseModel):
     """Configuration for harmonic pattern detection."""
 
     enabled: bool = True
+    tolerance: float = Field(
+        0.05,
+        description="Ratio matching tolerance for pattern validation",
+    )
+    window: int = Field(
+        5,
+        description="Look-back window when locating swing pivots",
+    )
     collection: str | None = Field(
         None, description="Target collection for harmonic pattern vectors"
     )
@@ -123,9 +133,7 @@ class VectorDBConfig(BaseModel):
 class EmbeddingConfig(BaseModel):
     """Embedding model configuration."""
 
-    model: str | None = Field(
-        None, description="Name of the embedding model to use"
-    )
+    model: str | None = Field(None, description="Name of the embedding model to use")
 
 
 class AdvancedConfig(BaseModel):
@@ -177,11 +185,23 @@ class EnrichmentConfig(BaseModel):
                 "ml_ensemble": self.advanced.elliott.ml_ensemble,
                 "llm_max_tokens": self.advanced.elliott.llm_max_tokens,
             },
+            "harmonic_processor": {
+                "enabled": self.advanced.harmonic.enabled,
+                "tolerance": self.advanced.harmonic.tolerance,
+                "window": self.advanced.harmonic.window,
+            },
         }
 
 
-def load_enrichment_config(path: str | Path = "config/enrichment_default.yaml") -> EnrichmentConfig:
-    """Load and validate enrichment configuration from YAML file."""
+def load_enrichment_config(
+    path: str | Path = "config/enrichment_default.yaml",
+) -> EnrichmentConfig:
+    """Load and validate enrichment configuration from YAML file.
+
+    Besides the default configuration, ``config/enrichment_harmonic.yaml``
+    is provided to enable harmonic pattern detection and vector database
+    persistence.  Pass the path to this function to activate the feature.
+    """
 
     path = Path(path)
     data: Dict[str, Any]


### PR DESCRIPTION
## Summary
- add harmonic-focused enrichment configuration with vector DB settings
- support harmonic tolerance and window in enrichment loader and core processor
- document harmonic config and loader usage

## Testing
- `pre-commit run --files config/enrichment_harmonic.yaml docs/enrichment_engine.md utils/enrichment_config.py services/enrichment/main.py core/harmonic_processor.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyarrow' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68c4e468767c832899be331b227024b3