### PR TITLE
chore: ensure web node_modules ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,5 @@ services/.env
 /dashboard/.cache
 /config/.dbus/session-bus
 
-# Node modules
+# Node modules for web frontend
 web/node_modules/


### PR DESCRIPTION
## Summary
- document that the web frontend's node_modules directory is ignored by git

## Testing
- `pre-commit run --files .gitignore`
- `cd web && npm install`

------
https://chatgpt.com/codex/tasks/task_b_68c4e57edfec8328ba4d84918e9e1d2f