### PR TITLE
Use env var for Slack webhook and document configuration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -146,6 +146,11 @@ CELERY_CONCURRENCY=3
 DISCORD_WEBHOOK_URL=your_discord_webhook_url_here
 
 # -----------------------------------------------------------------------------
+# SLACK NOTIFICATIONS (Optional)
+# -----------------------------------------------------------------------------
+SLACK_WEBHOOK_URL=your_slack_webhook_url_here
+
+# -----------------------------------------------------------------------------
 # TELEGRAM NOTIFICATIONS (Legacy - Optional)
 # -----------------------------------------------------------------------------
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here

--- a/config/alert_config.yaml
+++ b/config/alert_config.yaml
@@ -15,7 +15,7 @@ channels:
       - "risk@example.com"
   slack:
     enabled: false
-    webhook_url: ""
+    webhook_url: "${SLACK_WEBHOOK_URL}"
 
 alert_types:
   price_alerts:

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -12,6 +12,7 @@
 ## docker compose
 
 - Ensure `DJANGO_SECRET_KEY` only set once with default fallback
+- Provide `SLACK_WEBHOOK_URL` in the environment for Alertmanager Slack alerts
 - Celery/Celery Beat:
   - `entrypoint`: `celery -A app worker|beat`
   - `PYTHONPATH` includes: `/app/backend/django:/app/agents:/app:/app/components:/app/utils:/app/backend`

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -139,6 +139,13 @@ Define these in a dedicated `.env.discord` file which is referenced only by serv
 | `DISCORD_CHANNEL_ID` | `your_discord_channel_id_here` | Set to the channel ID that should receive messages. | Destination channel for Discord alerts. |
 | `DISCORD_WEBHOOK_URL` | `your_discord_webhook_url_here` | Replace with your webhook to enable default alerts. | Webhook endpoint used for sending alerts to Discord. |
 
+## Slack Notifications
+Environment variable used for Alertmanager Slack integration.
+
+| Variable | Default | Override Behavior | Purpose |
+| --- | --- | --- | --- |
+| `SLACK_WEBHOOK_URL` | _(empty)_ | Provide to enable Slack alert delivery. | Incoming webhook URL for Slack alerts. |
+
 ## Alert Settings
 | Variable | Default | Override Behavior | Purpose |
 | --- | --- | --- | --- |

--- a/docs/full-setup-guide.md
+++ b/docs/full-setup-guide.md
@@ -23,6 +23,7 @@ cp .env.template .env
 ```
 
 Ensure `POSTGRES_PASSWORD` is set to a strong value; the stack will not start without it.
+Optionally set `SLACK_WEBHOOK_URL` to route Alertmanager notifications to Slack.
 
 ## 3. Configure domain records
 

--- a/monitoring/configs/alertmanager/alertmanager-slack-config.yml
+++ b/monitoring/configs/alertmanager/alertmanager-slack-config.yml
@@ -2,7 +2,7 @@
 # https://rtfm.co.ua/en/prometheus-alertmanagers-alerts-receivers-and-routing-based-on-severity-level-and-tags/
 global:
   resolve_timeout: 5m
-  slack_api_url: 'https://hooks.slack.com/services/XXXXXXX/XXXXXXX/XXXXXXXXXXXXXX'
+  slack_api_url: '${SLACK_WEBHOOK_URL}'
 
 route:
   # https://www.robustperception.io/whats-the-difference-between-group_interval-group_wait-and-repeat_interval
@@ -83,7 +83,7 @@ receivers:
           {{ end }}
         username: 'AlertManager'
         icon_emoji: ':prometheus:'
-        #api_url: '__SLACK_WEBHOOK_URL__'
+        api_url: '${SLACK_WEBHOOK_URL}'
 
   - name: 'basic-slack'
     slack_configs:


### PR DESCRIPTION
## Summary
- replace hardcoded Slack webhook URL with `SLACK_WEBHOOK_URL`
- document Slack webhook environment variable in templates and deployment guides

## Testing
- `pytest tests/ops/test_replay_consumer.py -q` *(fails: ModuleNotFoundError: No module named 'pyarrow')*


------
https://chatgpt.com/codex/tasks/task_b_68c4e58e9b1883289cef4defdcb04cbc