### PR TITLE
Add Wyckoff detection tests and stub liquidity engine

### DIFF
--- a/dashboard/_mix/5_  🧠 SMC & WYCKOFF.py
+++ b/dashboard/_mix/5_  🧠 SMC & WYCKOFF.py
@@ -1,17 +1,19 @@
-"""QRT dashboard blending smart-money concepts with Wyckoff analysis.
+"""QRT dashboard blending smart‑money concepts with Wyckoff analysis.
 
-This module powers an interactive Streamlit dashboard.  The analytical core
-includes lightweight detectors for several Wyckoff events used throughout the
-app and exposed here for unit testing:
+This module backs an interactive Streamlit dashboard but also exposes a small
+collection of detection heuristics for unit testing.  The following Wyckoff
+events are recognised using straightforward logic:
 
-* **Selling climax** – identifies a sharp downward move on extreme volume.
-* **Accumulation range** – detects a period of reduced volatility and volume.
-* **Spring** – finds a temporary break below support that quickly reverses.
-* **Markup beginning** – flags a breakout above resistance with volume
-  expansion.
+* **Selling climax** – new low on a sharp drop and volume spike.
+* **Accumulation range** – contraction in price range accompanied by lower
+  volume.
+* **Spring** – temporary break of support that closes back above it.
+* **Markup beginning** – breakout above resistance with expanding volume.
 
-The detectors are intentionally simple and serve as placeholders for more
-advanced implementations.
+These detectors are intentionally lightweight yet fully functional and are
+covered by unit tests.  More sophisticated analytics (for example the
+``TiquidityEngine``) are outside the scope of this module and raise
+``NotImplementedError`` when invoked.
 """
 
 import streamlit as st
@@ -519,8 +521,34 @@ class QRTQuantumAnalyzer(QuantumMicrostructureAnalyzer):
 
 
 class TiquidityEngine:
-    """Engine for tick liquidity analysis"""
-    pass
+    """Engine for tick liquidity analysis.
+
+    The real liquidity engine lives in a separate service.  In the dashboard
+    context we only expose an interface so that the rest of the analyzer can be
+    instantiated during tests.  Any direct use of this stub will raise
+    :class:`NotImplementedError` to make the missing dependency explicit.
+    """
+
+    def analyze(self, df: pd.DataFrame) -> Dict[str, float]:
+        """Compute tick liquidity metrics for ``df``.
+
+        Parameters
+        ----------
+        df:
+            Price/volume data.
+
+        Returns
+        -------
+        Dict[str, float]
+            Calculated metrics.
+
+        Raises
+        ------
+        NotImplementedError
+            Always – the production engine is not bundled with the dashboard.
+        """
+
+        raise NotImplementedError("Tick liquidity analysis is not implemented in this stub.")
 
 
 class WyckoffQuantumAnalyzer:

--- a/tests/test_wyckoff_dashboard_detection.py
+++ b/tests/test_wyckoff_dashboard_detection.py
@@ -47,6 +47,18 @@ def test_detect_selling_climax():
     assert analyzer._detect_selling_climax(df)
 
 
+def test_no_selling_climax():
+    """No volume spike or new low should return False."""
+    analyzer = QRTAnalyzer(None)
+    df = pd.DataFrame({
+        "close": [10, 9.9, 9.8, 9.7, 9.6],
+        "low": [9.8, 9.7, 9.6, 9.5, 9.4],
+        "high": [10.2, 10.1, 10.0, 9.9, 9.8],
+        "volume": [100, 100, 100, 100, 100],
+    })
+    assert not analyzer._detect_selling_climax(df)
+
+
 def test_detect_accumulation_range():
     analyzer = QRTAnalyzer(None)
     trend_prices = pd.Series(np.linspace(30, 20, 10))
@@ -61,6 +73,16 @@ def test_detect_accumulation_range():
     assert analyzer._detect_accumulation_range(df)
 
 
+def test_no_accumulation_range():
+    analyzer = QRTAnalyzer(None)
+    df = pd.DataFrame({
+        "high": [1, 3, 5, 7, 9],
+        "low": [0, 2, 4, 6, 8],
+        "volume": [100, 200, 300, 400, 500],
+    })
+    assert not analyzer._detect_accumulation_range(df)
+
+
 def test_detect_spring():
     analyzer = QRTAnalyzer(None)
     df = pd.DataFrame({
@@ -72,6 +94,15 @@ def test_detect_spring():
     assert spring_idx == len(df) - 1
 
 
+def test_no_spring():
+    analyzer = QRTAnalyzer(None)
+    df = pd.DataFrame({
+        "close": [10, 10.1, 10.2, 10.3],
+        "low": [9.8, 9.9, 10.0, 10.1],
+    })
+    assert analyzer._detect_spring(df) is None
+
+
 def test_detect_markup_beginning():
     analyzer = QRTAnalyzer(None)
     df = pd.DataFrame({
@@ -81,3 +112,13 @@ def test_detect_markup_beginning():
         "volume": [100, 100, 100, 100, 300]
     })
     assert analyzer._detect_markup_beginning(df)
+
+
+def test_no_markup_beginning():
+    analyzer = QRTAnalyzer(None)
+    df = pd.DataFrame({
+        "close": [10, 10.05, 10.1, 10.08, 10.09],
+        "high": [10.2, 10.15, 10.2, 10.1, 10.12],
+        "volume": [100, 100, 100, 100, 100],
+    })
+    assert not analyzer._detect_markup_beginning(df)


### PR DESCRIPTION
## Summary
- document simple Wyckoff detection heuristics and expose unimplemented liquidity stub
- cover positive and negative cases for selling climax, accumulation range, spring, and markup breakout

## Testing
- `pytest tests/test_wyckoff_dashboard_detection.py`

------
https://chatgpt.com/codex/tasks/task_b_68c4e58d398883289520f1e67c9cbdb7