### PR TITLE
Add HarmonicResult schema for harmonic analysis output

### DIFF
--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -3,6 +3,7 @@
 from .payloads import (
     ISPTSPipelineResult,  # ISPTS pipeline stage outputs
     HarmonicPattern,
+    HarmonicResult,
     MarketContext,
     MicrostructureAnalysis,
     PredictiveAnalysisResult,
@@ -36,6 +37,7 @@ __all__ = (
     "ConflictDetectionResult",
     "HealthStatus",
     "HarmonicPattern",
+    "HarmonicResult",
     "ISPTSPipelineResult",
     "MarketContext",
     "MicrostructureAnalysis",

--- a/schemas/payloads.py
+++ b/schemas/payloads.py
@@ -13,9 +13,7 @@ class MarketContext(BaseModel):
 
     symbol: str = Field(..., description="Instrument identifier")
     timeframe: str = Field(..., description="Timeframe of the context, e.g. 1m or 1h")
-    session: Optional[str] = Field(
-        None, description="Optional trading session label"
-    )
+    session: Optional[str] = Field(None, description="Optional trading session label")
     trend: Optional[str] = Field(
         None, description="Textual trend description such as bullish or bearish"
     )
@@ -27,15 +25,11 @@ class MarketContext(BaseModel):
 class TechnicalIndicators(BaseModel):
     """Common technical indicator values"""
 
-    rsi: Optional[float] = Field(
-        None, description="Relative Strength Index value"
-    )
+    rsi: Optional[float] = Field(None, description="Relative Strength Index value")
     macd: Optional[float] = Field(
         None, description="Moving Average Convergence Divergence value"
     )
-    vwap: Optional[float] = Field(
-        None, description="Volume weighted average price"
-    )
+    vwap: Optional[float] = Field(None, description="Volume weighted average price")
     moving_averages: Dict[str, float] = Field(
         default_factory=dict, description="Mapping of moving average name to value"
     )
@@ -51,7 +45,8 @@ class SMCAnalysis(BaseModel):
         None, description="Market structure label such as bullish or bearish"
     )
     poi: List[str] = Field(
-        default_factory=list, description="Points of interest discovered by the analysis"
+        default_factory=list,
+        description="Points of interest discovered by the analysis",
     )
     liquidity_pools: List[str] = Field(
         default_factory=list, description="Identified liquidity pool identifiers"
@@ -78,9 +73,7 @@ class MicrostructureAnalysis(BaseModel):
     realized_spread: Optional[float] = Field(
         None, description="Realized spread measure"
     )
-    price_impact: Optional[float] = Field(
-        None, description="Price impact of trades"
-    )
+    price_impact: Optional[float] = Field(None, description="Price impact of trades")
     liquidity_score: Optional[float] = Field(
         None, description="Derived liquidity score"
     )
@@ -102,8 +95,24 @@ class HarmonicPattern(BaseModel):
         description="Potential reversal zone boundaries",
     )
     confidence: float = Field(
-        0.0, description="Confidence score for the pattern",
+        0.0,
+        description="Confidence score for the pattern",
     )
+
+
+class HarmonicResult(BaseModel):
+    """Aggregated harmonic pattern detection results."""
+
+    harmonic_patterns: List[Dict[str, Any]] = Field(
+        default_factory=list, description="List of detected harmonic patterns"
+    )
+    prz: Dict[str, float] = Field(
+        default_factory=dict, description="Potential reversal zone boundaries"
+    )
+    confidence: float = Field(
+        0.0, description="Overall confidence score across patterns"
+    )
+
 
 class PredictiveAnalysisResult(BaseModel):
     """Aggregated predictive scoring and conflict detection."""
@@ -124,26 +133,33 @@ class ISPTSPipelineResult(BaseModel):
     """Outputs from each stage of the ISPTS pipeline."""
 
     context_analyzer: Any = Field(
-        ..., description="Context analyzer stage output",
+        ...,
+        description="Context analyzer stage output",
     )
     liquidity_engine: Any = Field(
-        ..., description="Liquidity engine stage output",
+        ...,
+        description="Liquidity engine stage output",
     )
     structure_validator: Any = Field(
-        ..., description="Structure validator stage output",
+        ...,
+        description="Structure validator stage output",
     )
     fvg_locator: Any = Field(
-        ..., description="FVG locator stage output",
+        ...,
+        description="FVG locator stage output",
     )
     harmonic_processor: Any = Field(
-        ..., description="Harmonic processor stage output",
+        ...,
+        description="Harmonic processor stage output",
     )
 
     risk_manager: Any = Field(
-        ..., description="Risk manager stage output",
+        ...,
+        description="Risk manager stage output",
     )
     confluence_stacker: Any = Field(
-        ..., description="Confluence stacker stage output",
+        ...,
+        description="Confluence stacker stage output",
     )
     harmonic: HarmonicResult = Field(
         default_factory=HarmonicResult,
@@ -165,12 +181,8 @@ class UnifiedAnalysisPayloadV1(BaseModel):
     technical_indicators: TechnicalIndicators = Field(
         ..., description="Common technical indicator values"
     )
-    smc: SMCAnalysis = Field(
-        ..., description="Smart Money Concepts analysis results"
-    )
-    wyckoff: WyckoffAnalysis = Field(
-        ..., description="Wyckoff model state"
-    )
+    smc: SMCAnalysis = Field(..., description="Smart Money Concepts analysis results")
+    wyckoff: WyckoffAnalysis = Field(..., description="Wyckoff model state")
     microstructure: MicrostructureAnalysis = Field(
         ..., description="Order flow and microstructure metrics"
     )
@@ -179,10 +191,12 @@ class UnifiedAnalysisPayloadV1(BaseModel):
         description="Harmonic pattern detection results",
     )
     predictive_analysis: PredictiveAnalysisResult = Field(
-        ..., description="Aggregated predictive scoring and conflict detection results",
+        ...,
+        description="Aggregated predictive scoring and conflict detection results",
     )
     ispts_pipeline: ISPTSPipelineResult = Field(
-        ..., description="Outputs from each stage of the ISPTS pipeline",
+        ...,
+        description="Outputs from each stage of the ISPTS pipeline",
     )
     extras: Dict[str, Any] = Field(
         default_factory=dict,


### PR DESCRIPTION
## Summary
- introduce `HarmonicResult` Pydantic model to capture harmonic patterns, PRZ and confidence
- export `HarmonicResult` from schemas package

## Testing
- `pre-commit run --files schemas/payloads.py schemas/__init__.py`
- `pytest tests/test_harmonic_unified_analysis.py`


------
https://chatgpt.com/codex/tasks/task_b_68c4e56af00c832893fcd9d23dc1a087