### PR TITLE
Capture harmonic output in enrichment pipeline

### DIFF
--- a/services/enrichment/pipeline.py
+++ b/services/enrichment/pipeline.py
@@ -78,7 +78,10 @@ def run(
             before_keys = set(state.keys())
             state = runner(state, cfg)
             new_keys = set(state.keys()) - before_keys
-            outputs[name] = {k: state[k] for k in new_keys}
+            module_output = {k: state[k] for k in new_keys}
+            if name == "harmonic_processor" and "harmonic" in state:
+                module_output = state["harmonic"]
+            outputs[name] = module_output
         except Exception as exc:  # pragma: no cover - safeguard
             state["status"] = "FAIL"
             state.setdefault("errors", {})[name] = str(exc)


### PR DESCRIPTION
## Summary
- collect harmonic processor output directly from `state["harmonic"]`

## Testing
- `pytest tests/test_enrichment_pipeline.py::test_pipeline_runs_all -q`
- `pytest tests/test_enrichment_pipeline.py::test_pipeline_stops_on_failure -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4e56ae7008328b7f9a381ca352d3f