### PR TITLE
Aggregate harmonic pattern results

### DIFF
--- a/schemas/payloads.py
+++ b/schemas/payloads.py
@@ -97,12 +97,29 @@ class HarmonicPattern(BaseModel):
         default_factory=list,
         description="List of pivot points with index and price",
     )
-    prz: Dict[str, float] = Field(
+    prz: Dict[str, float | None] = Field(
         default_factory=dict,
         description="Potential reversal zone boundaries",
     )
     confidence: float = Field(
         0.0, description="Confidence score for the pattern",
+    )
+
+
+class HarmonicResult(BaseModel):
+    """Harmonic pattern detection results."""
+
+    harmonic_patterns: List[HarmonicPattern] = Field(
+        default_factory=list,
+        description="List of detected harmonic patterns",
+    )
+    prz: Dict[str, float | None] = Field(
+        default_factory=dict,
+        description="Aggregated potential reversal zone boundaries",
+    )
+    confidence: float = Field(
+        0.0,
+        description="Aggregated confidence score",
     )
 
 class PredictiveAnalysisResult(BaseModel):

--- a/services/enrichment/modules/harmonic_processor.py
+++ b/services/enrichment/modules/harmonic_processor.py
@@ -5,16 +5,21 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from core.harmonic_processor import HarmonicProcessor
-from enrichment.enrichment_engine import run_data_module
+from enrichment.enrichment_engine import ensure_dataframe
 
 
 def run(state: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
     """Populate ``state`` with harmonic pattern analysis."""
-    return run_data_module(
-        state,
-        required_cols=("open", "high", "low", "close"),
-        engine_factory=lambda: HarmonicProcessor(**config),
-    )
+    df = ensure_dataframe(state, ("open", "high", "low", "close"))
+    if df is None:
+        return state
+    engine = HarmonicProcessor(**config)
+    result = engine.analyze(df)
+    harmonic = result.get("harmonic")
+    if harmonic is not None:
+        state["harmonic"] = harmonic
+    state["status"] = "PASS"
+    return state
 
 
 __all__ = ["run"]

--- a/tests/test_advanced_processor.py
+++ b/tests/test_advanced_processor.py
@@ -185,28 +185,28 @@ def test_elliott_wave_llm_integration_mocked(mock_llm_infer, sample_df):
 
 def test_detect_harmonic_patterns_bullish():
     df = _generate_abcd_dataframe(bullish=True)
-    result = detect_harmonic_patterns(df)
-    patterns = result["harmonic_patterns"]
-    assert patterns and patterns[0]["pattern"] == "ABCD"
-    prz = patterns[0]["prz"]
-    assert pytest.approx(prz["min"], rel=1e-3) == -1.0
-    assert pytest.approx(prz["max"], rel=1e-3) == 2.33
-    assert patterns[0]["confidence"] > 0
+    result = detect_harmonic_patterns(df)["harmonic"]
+    patterns = result.harmonic_patterns
+    assert patterns and patterns[0].pattern == "ABCD"
+    prz = patterns[0].prz
+    assert pytest.approx(prz["low"], rel=1e-3) == -1.0
+    assert pytest.approx(prz["high"], rel=1e-3) == 2.33
+    assert patterns[0].confidence > 0
 
 
 def test_detect_harmonic_patterns_bearish():
     df = _generate_abcd_dataframe(bullish=False)
-    result = detect_harmonic_patterns(df)
-    patterns = result["harmonic_patterns"]
-    assert patterns and patterns[0]["pattern"] == "ABCD"
-    prz = patterns[0]["prz"]
-    assert pytest.approx(prz["min"], rel=1e-3) == -2.33
-    assert pytest.approx(prz["max"], rel=1e-3) == 1.0
-    assert patterns[0]["confidence"] > 0
+    result = detect_harmonic_patterns(df)["harmonic"]
+    patterns = result.harmonic_patterns
+    assert patterns and patterns[0].pattern == "ABCD"
+    prz = patterns[0].prz
+    assert pytest.approx(prz["low"], rel=1e-3) == -2.33
+    assert pytest.approx(prz["high"], rel=1e-3) == 1.0
+    assert patterns[0].confidence > 0
 
 
 def test_detect_harmonic_patterns_none():
     close = np.linspace(1, 50, 60)
     df = pd.DataFrame({"open": close, "high": close, "low": close, "close": close})
-    result = detect_harmonic_patterns(df)
-    assert result["harmonic_patterns"] == []
+    result = detect_harmonic_patterns(df)["harmonic"]
+    assert result.harmonic_patterns == []

--- a/tests/test_enrichment_pipeline.py
+++ b/tests/test_enrichment_pipeline.py
@@ -38,9 +38,10 @@ def test_pipeline_runs_all(monkeypatch) -> None:
     assert "liquidity_zones" in state
     assert "wyckoff_analysis" in state
     assert "maturity_score" in state
-    assert "harmonic_patterns" in state
-    assert "prz" in state
-    assert "confidence" in state
+    assert "harmonic" in state
+    assert hasattr(state["harmonic"], "harmonic_patterns")
+    assert hasattr(state["harmonic"], "prz")
+    assert hasattr(state["harmonic"], "confidence")
 
 
 def test_pipeline_stops_on_failure(monkeypatch) -> None:

--- a/tests/test_harmonic_unified_analysis.py
+++ b/tests/test_harmonic_unified_analysis.py
@@ -35,6 +35,6 @@ def test_build_unified_analysis_includes_harmonic():
     }
     payload = ae.build_unified_analysis(tick, cfg)
     harmonic = payload.harmonic
-    assert harmonic.harmonic_patterns[0]["pattern"] == "bat"
+    assert harmonic.harmonic_patterns[0].pattern == "bat"
     assert harmonic.prz == {"low": 1.0, "high": 1.2}
     assert harmonic.confidence == 0.9


### PR DESCRIPTION
## Summary
- add `HarmonicResult` schema to encapsulate harmonic pattern analysis
- aggregate potential reversal zone and confidence in `HarmonicProcessor`
- update enrichment module and tests to use nested `harmonic` results

## Testing
- `pytest tests/test_advanced_processor.py::test_detect_harmonic_patterns_bullish tests/test_advanced_processor.py::test_detect_harmonic_patterns_bearish tests/test_advanced_processor.py::test_detect_harmonic_patterns_none -q`
- `pytest tests/test_harmonic_unified_analysis.py -q`
- `pytest tests/test_enrichment_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68c4e56ae3b883288a9a0123662bd2f3