### PR TITLE
Rename harmonic storage processor

### DIFF
--- a/tests/test_harmonic_storage_processor.py
+++ b/tests/test_harmonic_storage_processor.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils.processors.harmonic import HarmonicVectorStore
+from utils.processors.harmonic import HarmonicStorageProcessor
 
 
 class DummySyncClient:
@@ -22,7 +22,7 @@ class DummyAsyncClient:
 @pytest.mark.asyncio
 async def test_upsert_uses_background_thread_for_sync_client():
     client = DummySyncClient()
-    store = HarmonicVectorStore(client)
+    store = HarmonicStorageProcessor(client)
     await store.upsert([[0.1]], [{}], [1])
     assert client.called
 
@@ -30,6 +30,6 @@ async def test_upsert_uses_background_thread_for_sync_client():
 @pytest.mark.asyncio
 async def test_upsert_awaits_async_client():
     client = DummyAsyncClient()
-    store = HarmonicVectorStore(client)
+    store = HarmonicStorageProcessor(client)
     await store.upsert([[0.1]], [{}], [1])
     assert client.called

--- a/utils/harmonic_embeddings.py
+++ b/utils/harmonic_embeddings.py
@@ -1,10 +1,9 @@
 """Embed harmonic pattern features and store them asynchronously in Qdrant.
 
-This module previously handled Qdrant upserts directly.  It now delegates the
-storage operation to :class:`utils.processors.harmonic.HarmonicProcessor` which
-provides an awaitable interface capable of working with both synchronous and
-asynchronous Qdrant clients.  The public API is kept as a thin async wrapper so
-existing call sites can simply ``await`` the new implementation.
+The actual upsert is delegated to
+:class:`utils.processors.harmonic.HarmonicStorageProcessor`, an awaitable
+utility dedicated solely to Qdrant persistence (pattern analysis is handled by
+``core.harmonic_processor``).
 """
 
 from __future__ import annotations
@@ -15,7 +14,7 @@ from typing import Any, Dict, Iterable, List
 
 from qdrant_client import QdrantClient
 
-from utils.processors.harmonic import HarmonicProcessor
+from utils.processors.harmonic import HarmonicStorageProcessor
 
 try:  # pragma: no cover - best effort fallback when deps missing
     from services.mcp2.vector.embeddings import embed
@@ -60,7 +59,7 @@ async def upsert_harmonic_patterns(
         api_key = os.getenv("QDRANT_API_KEY")
         client = QdrantClient(url=url, api_key=api_key)
 
-    processor = HarmonicProcessor(client, collection_name)
+    processor = HarmonicStorageProcessor(client, collection_name)
 
     vectors: List[List[float]] = []
     payloads: List[Dict[str, Any]] = []

--- a/utils/processors/__init__.py
+++ b/utils/processors/__init__.py
@@ -2,8 +2,8 @@
 
 The ``advanced`` processor depends on optional third‑party libraries such as
 ``talib``.  Import failures for these heavy dependencies are gracefully handled
-so lighter‑weight utilities (e.g. :class:`HarmonicProcessor`) remain available
-without requiring the full stack during test runs.
+so lighter‑weight utilities (e.g. :class:`HarmonicStorageProcessor`) remain
+available without requiring the full stack during test runs.
 """
 
 from __future__ import annotations
@@ -14,6 +14,11 @@ except Exception:  # pragma: no cover - ignore when deps missing
     AdvancedProcessor = RLAgent = None  # type: ignore[assignment]
 
 from .structure import StructureProcessor
-from .harmonic import HarmonicVectorStore
+from .harmonic import HarmonicStorageProcessor
 
-__all__ = ["AdvancedProcessor", "StructureProcessor", "RLAgent", "HarmonicVectorStore"]
+__all__ = [
+    "AdvancedProcessor",
+    "StructureProcessor",
+    "RLAgent",
+    "HarmonicStorageProcessor",
+]

--- a/utils/processors/harmonic.py
+++ b/utils/processors/harmonic.py
@@ -1,14 +1,8 @@
-"""Harmonic pattern utilities with asynchronous Qdrant insertion.
+"""Asynchronous storage for harmonic pattern vectors.
 
-This module exposes :class:`HarmonicVectorStore` which mirrors the style of
-other processors under :mod:`utils.processors`. The store accepts either an
-:class:`qdrant_client.AsyncQdrantClient` or the traditional synchronous
-:class:`qdrant_client.QdrantClient`. Inserts are executed in a non-blocking
-fashion: asynchronous clients are awaited directly while synchronous clients
-are dispatched to a background thread using :func:`asyncio.to_thread`.
-
-The goal is to provide a simple, awaitable interface for storing detected
-harmonic patterns without blocking the event loop.
+This module is only responsible for upserting harmonic pattern embeddings into
+Qdrant.  It deliberately avoids performing any pattern *analysis* to keep the
+storage concern separate from :mod:`core.harmonic_processor`.
 """
 
 from __future__ import annotations
@@ -20,8 +14,8 @@ from typing import Iterable, Sequence
 from qdrant_client import models
 
 
-class HarmonicVectorStore:
-    """Processor responsible for persisting harmonic pattern vectors."""
+class HarmonicStorageProcessor:
+    """Persist harmonic pattern vectors into a Qdrant collection."""
 
     def __init__(self, client: object, collection_name: str = "harmonic") -> None:
         """Initialize the processor with a Qdrant client.
@@ -67,4 +61,4 @@ class HarmonicVectorStore:
             )
 
 
-__all__ = ["HarmonicVectorStore"]
+__all__ = ["HarmonicStorageProcessor"]


### PR DESCRIPTION
## Summary
- rename `HarmonicProcessor` to `HarmonicStorageProcessor`
- clarify harmonic storage module responsibilities
- update imports and tests for new processor name

## Testing
- `pytest tests/test_harmonic_storage_processor.py tests/test_harmonic_embeddings.py`


------
https://chatgpt.com/codex/tasks/task_b_68c4e7986f6083288f8b3e34591505c5