### PR TITLE
Add harmonic dashboard payload conversion

### DIFF
--- a/dashboard/pages/pulse.py
+++ b/dashboard/pages/pulse.py
@@ -6,6 +6,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
+
 # -----------------------------------------------------------------------------
 # Cached connections
 # -----------------------------------------------------------------------------
@@ -86,7 +87,10 @@ def fetch_latest_message() -> Optional[Dict[str, Any]]:
 # Chart utilities (adapted from dashboard/_mix/🧠 SMC.py)
 # -----------------------------------------------------------------------------
 
-def render_harmonic_chart(df: pd.DataFrame, patterns: List[Dict[str, Any]]) -> go.Figure:
+
+def render_harmonic_chart(
+    df: pd.DataFrame, patterns: List[Dict[str, Any]]
+) -> go.Figure:
     """Render OHLC chart with harmonic overlays and PRZ shading."""
     fig = go.Figure(
         data=[
@@ -126,17 +130,15 @@ def render_harmonic_chart(df: pd.DataFrame, patterns: List[Dict[str, Any]]) -> g
             )
 
         # PRZ shading
-        prz = pattern.get("prz") or {
-            "low": pattern.get("prz_low"),
-            "high": pattern.get("prz_high"),
-        }
-        if prz.get("low") is not None and prz.get("high") is not None:
+        prz_low = pattern.get("prz_low")
+        prz_high = pattern.get("prz_high")
+        if prz_low is not None and prz_high is not None:
             fig.add_shape(
                 type="rect",
                 x0=df.index[0],
                 x1=df.index[-1],
-                y0=prz["low"],
-                y1=prz["high"],
+                y0=prz_low,
+                y1=prz_high,
                 fillcolor="rgba(255,0,0,0.1)",
                 line=dict(width=0),
             )
@@ -189,4 +191,3 @@ else:
             "https://actions.google.com/sounds/v1/alarms/beep_short.ogg",
             autoplay=True,
         )
-

--- a/services/enrichment/dashboard_adapter.py
+++ b/services/enrichment/dashboard_adapter.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Sequence
+
+from schemas import UnifiedAnalysisPayloadV1
+
+
+def to_dashboard_payload(
+    payload: UnifiedAnalysisPayloadV1, bars: Sequence[Dict[str, Any]] | None
+) -> Dict[str, Any]:
+    """Convert a unified analysis payload to the dashboard schema.
+
+    Parameters
+    ----------
+    payload:
+        The unified analysis payload produced by the enrichment pipeline.
+    bars:
+        Sequence of OHLC bars used during analysis. Each bar should contain
+        ``time`` (or ``timestamp``), ``open``, ``high``, ``low`` and ``close``.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary structured according to ``pulse_dashboard_config.yaml``.
+    """
+
+    bars = list(bars or [])
+    ohlc = [
+        {
+            "time": b.get("time") or b.get("timestamp"),
+            "open": b.get("open"),
+            "high": b.get("high"),
+            "low": b.get("low"),
+            "close": b.get("close"),
+        }
+        for b in bars
+    ]
+
+    patterns = []
+    for pat in payload.harmonic.harmonic_patterns:
+        entry: Dict[str, Any] = {
+            "pattern_type": pat.pattern,
+            "confidence": pat.confidence,
+        }
+        for idx, point in enumerate(pat.points[:5], start=1):
+            ts = None
+            i = point.get("index")
+            if i is not None:
+                i = int(i)
+                if 0 <= i < len(bars):
+                    ts = bars[i].get("time") or bars[i].get("timestamp")
+            entry[f"point{idx}_time"] = ts
+            entry[f"point{idx}_price"] = point.get("price")
+        entry["prz_low"] = pat.prz.get("min") or pat.prz.get("low")
+        entry["prz_high"] = pat.prz.get("max") or pat.prz.get("high")
+        patterns.append(entry)
+
+    timestamp = payload.timestamp
+    if isinstance(timestamp, datetime):
+        timestamp_str = timestamp.isoformat()
+    else:
+        timestamp_str = str(timestamp)
+
+    return {
+        "symbol": payload.symbol,
+        "timestamp": timestamp_str,
+        "ohlc": ohlc,
+        "harmonic_patterns": patterns,
+    }
+
+
+__all__ = ["to_dashboard_payload"]

--- a/tests/test_dashboard_payload.py
+++ b/tests/test_dashboard_payload.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+
+from services.enrichment.dashboard_adapter import to_dashboard_payload
+from schemas import (
+    ConflictDetectionResult,
+    HarmonicPattern,
+    HarmonicResult,
+    ISPTSPipelineResult,
+    MarketContext,
+    MicrostructureAnalysis,
+    PredictiveAnalysisResult,
+    PredictiveScorerResult,
+    SMCAnalysis,
+    TechnicalIndicators,
+    UnifiedAnalysisPayloadV1,
+    WyckoffAnalysis,
+)
+
+
+def _dummy_pipeline_result() -> ISPTSPipelineResult:
+    return ISPTSPipelineResult(
+        context_analyzer={},
+        liquidity_engine={},
+        structure_validator={},
+        fvg_locator={},
+        harmonic_processor={},
+        risk_manager={},
+        confluence_stacker={},
+        harmonic=HarmonicResult(),
+    )
+
+
+def test_dashboard_payload_conversion() -> None:
+    bars = [
+        {
+            "time": f"2024-01-01T00:0{i}:00",
+            "open": i,
+            "high": i + 0.5,
+            "low": i - 0.5,
+            "close": i,
+        }
+        for i in range(1, 6)
+    ]
+
+    pattern = HarmonicPattern(
+        pattern="BAT",
+        points=[{"index": i - 1, "price": float(i)} for i in range(1, 6)],
+        prz={"min": 1.0, "max": 5.0},
+        confidence=0.9,
+    )
+
+    payload = UnifiedAnalysisPayloadV1(
+        symbol="EURUSD",
+        timeframe="1m",
+        timestamp=datetime.fromisoformat("2024-01-01T00:05:00"),
+        market_context=MarketContext(symbol="EURUSD", timeframe="1m"),
+        technical_indicators=TechnicalIndicators(),
+        smc=SMCAnalysis(),
+        wyckoff=WyckoffAnalysis(),
+        microstructure=MicrostructureAnalysis(),
+        harmonic=HarmonicResult(harmonic_patterns=[pattern]),
+        predictive_analysis=PredictiveAnalysisResult(
+            scorer=PredictiveScorerResult(
+                maturity_score=0.0,
+                grade=None,
+                confidence_factors=[],
+                extras={"components": {}, "details": {}},
+            ),
+            conflict_detection=ConflictDetectionResult(is_conflict=False),
+        ),
+        ispts_pipeline=_dummy_pipeline_result(),
+    )
+
+    result = to_dashboard_payload(payload, bars)
+    assert result["symbol"] == "EURUSD"
+    assert result["ohlc"][0]["time"] == bars[0]["time"]
+    pattern_out = result["harmonic_patterns"][0]
+    assert pattern_out["pattern_type"] == "BAT"
+    assert pattern_out["point1_time"] == bars[0]["time"]
+    assert pattern_out["point1_price"] == 1.0
+    assert pattern_out["prz_low"] == 1.0
+    assert pattern_out["prz_high"] == 5.0


### PR DESCRIPTION
## Summary
- convert unified analysis output into dashboard schema via `to_dashboard_payload`
- stream converted payload to Redis for Pulse dashboard consumption
- update Pulse page to use `prz_low`/`prz_high` and test conversion logic

## Testing
- `pre-commit run --files services/enrichment/dashboard_adapter.py services/enrichment/handler.py dashboard/pages/pulse.py tests/test_dashboard_payload.py`
- `pytest tests/test_dashboard_payload.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4e7995e7c8328963c1e27f5a44474