### PR TITLE
Implement microstructure filter and integrate into hybrid pipeline

### DIFF
--- a/tests/test_microstructure_filter.py
+++ b/tests/test_microstructure_filter.py
@@ -1,0 +1,18 @@
+import pandas as pd
+from utils.microstructure_filter import microstructure_filter
+
+
+def test_microstructure_filter_removes_wide_spread_or_low_liquidity():
+    df = pd.DataFrame(
+        {
+            "spread": [0.01, 0.10, 0.03],
+            "liquidity_score": [1.2, 0.2, 1.5],
+            "mid_price": [100.0, 101.0, 102.0],
+        }
+    )
+
+    filtered = microstructure_filter(df, max_spread=0.05, min_liquidity=1.0)
+
+    assert len(filtered) == 2
+    assert filtered["spread"].max() <= 0.05
+    assert filtered["liquidity_score"].min() >= 1.0

--- a/utils/hybrid_data_pipeline.py
+++ b/utils/hybrid_data_pipeline.py
@@ -10,6 +10,7 @@ import pyarrow.parquet as pq
 import pyarrow as pa
 from concurrent.futures import ThreadPoolExecutor
 from core.data.manager import get_data_manager
+from .microstructure_filter import microstructure_filter
 
 @dataclass
 class DataConfig:
@@ -140,7 +141,6 @@ class HybridDataPipeline:
         # Start with standard
         df = self._standard_enrichment(df)
 
-        # Advanced microstructure
         df['realized_spread'] = self._calculate_realized_spread(df)
         df['price_impact'] = self._calculate_price_impact(df)
         df['liquidity_score'] = self._calculate_liquidity_score(df)
@@ -151,7 +151,7 @@ class HybridDataPipeline:
         df['trend_strength'] = self._calculate_trend_strength(df)
 
         df['enrichment_level'] = 'full'
-        return df
+        return microstructure_filter(df)
 
     def _calculate_rsi(self, prices: pd.Series, period: int = 14) -> pd.Series:
         """Calculate RSI"""

--- a/utils/microstructure_filter.py
+++ b/utils/microstructure_filter.py
@@ -1,0 +1,41 @@
+import pandas as pd
+
+
+def microstructure_filter(
+    df: pd.DataFrame,
+    spread_column: str = "spread",
+    liquidity_column: str = "liquidity_score",
+    *,
+    max_spread: float = 0.05,
+    min_liquidity: float = 0.0,
+) -> pd.DataFrame:
+    """Filter out observations with poor market microstructure.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing microstructure metrics.
+    spread_column:
+        Name of the column with spread values.  Rows with spreads greater
+        than ``max_spread`` are removed.
+    liquidity_column:
+        Name of the column with liquidity scores.  Rows with liquidity
+        scores lower than ``min_liquidity`` are removed.
+    max_spread:
+        Maximum acceptable spread.  Defaults to ``0.05``.
+    min_liquidity:
+        Minimum acceptable liquidity score.  Defaults to ``0.0``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Filtered DataFrame containing only rows that satisfy the
+        microstructure quality thresholds.  If the required columns are
+        missing, the input DataFrame is returned unchanged.
+    """
+
+    if spread_column not in df.columns or liquidity_column not in df.columns:
+        return df
+
+    mask = (df[spread_column] <= max_spread) & (df[liquidity_column] >= min_liquidity)
+    return df.loc[mask].copy()


### PR DESCRIPTION
## Summary
- add microstructure_filter to remove ticks with large spreads or weak liquidity
- integrate microstructure_filter into HybridDataPipeline full enrichment
- cover microstructure filtering with unit test

## Testing
- `pytest tests/test_microstructure_filter.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4e8b303ec8328bf2be305ab9c7e0e