### PR TITLE
Move harmonic data under pipeline

### DIFF
--- a/schemas/payloads.py
+++ b/schemas/payloads.py
@@ -13,9 +13,7 @@ class MarketContext(BaseModel):
 
     symbol: str = Field(..., description="Instrument identifier")
     timeframe: str = Field(..., description="Timeframe of the context, e.g. 1m or 1h")
-    session: Optional[str] = Field(
-        None, description="Optional trading session label"
-    )
+    session: Optional[str] = Field(None, description="Optional trading session label")
     trend: Optional[str] = Field(
         None, description="Textual trend description such as bullish or bearish"
     )
@@ -27,15 +25,11 @@ class MarketContext(BaseModel):
 class TechnicalIndicators(BaseModel):
     """Common technical indicator values"""
 
-    rsi: Optional[float] = Field(
-        None, description="Relative Strength Index value"
-    )
+    rsi: Optional[float] = Field(None, description="Relative Strength Index value")
     macd: Optional[float] = Field(
         None, description="Moving Average Convergence Divergence value"
     )
-    vwap: Optional[float] = Field(
-        None, description="Volume weighted average price"
-    )
+    vwap: Optional[float] = Field(None, description="Volume weighted average price")
     moving_averages: Dict[str, float] = Field(
         default_factory=dict, description="Mapping of moving average name to value"
     )
@@ -51,7 +45,8 @@ class SMCAnalysis(BaseModel):
         None, description="Market structure label such as bullish or bearish"
     )
     poi: List[str] = Field(
-        default_factory=list, description="Points of interest discovered by the analysis"
+        default_factory=list,
+        description="Points of interest discovered by the analysis",
     )
     liquidity_pools: List[str] = Field(
         default_factory=list, description="Identified liquidity pool identifiers"
@@ -78,9 +73,7 @@ class MicrostructureAnalysis(BaseModel):
     realized_spread: Optional[float] = Field(
         None, description="Realized spread measure"
     )
-    price_impact: Optional[float] = Field(
-        None, description="Price impact of trades"
-    )
+    price_impact: Optional[float] = Field(None, description="Price impact of trades")
     liquidity_score: Optional[float] = Field(
         None, description="Derived liquidity score"
     )
@@ -102,7 +95,8 @@ class HarmonicPattern(BaseModel):
         description="Potential reversal zone boundaries",
     )
     confidence: float = Field(
-        0.0, description="Confidence score for the pattern",
+        0.0,
+        description="Confidence score for the pattern",
     )
 
 
@@ -118,7 +112,8 @@ class HarmonicResult(BaseModel):
         description="Potential reversal zone boundaries",
     )
     confidence: float = Field(
-        0.0, description="Confidence score for the detected patterns",
+        0.0,
+        description="Confidence score for the detected patterns",
     )
 
 
@@ -141,16 +136,24 @@ class ISPTSPipelineResult(BaseModel):
     """Outputs from each stage of the ISPTS pipeline."""
 
     context_analyzer: Any = Field(
-        ..., description="Context analyzer stage output",
+        ...,
+        description="Context analyzer stage output",
     )
     liquidity_engine: Any = Field(
-        ..., description="Liquidity engine stage output",
+        ...,
+        description="Liquidity engine stage output",
     )
     structure_validator: Any = Field(
-        ..., description="Structure validator stage output",
+        ...,
+        description="Structure validator stage output",
     )
     fvg_locator: Any = Field(
-        ..., description="FVG locator stage output",
+        ...,
+        description="FVG locator stage output",
+    )
+    harmonic_processor: HarmonicResult = Field(
+        default_factory=HarmonicResult,
+        description="Harmonic pattern detection results",
     )
 
 
@@ -168,24 +171,18 @@ class UnifiedAnalysisPayloadV1(BaseModel):
     technical_indicators: TechnicalIndicators = Field(
         ..., description="Common technical indicator values"
     )
-    smc: SMCAnalysis = Field(
-        ..., description="Smart Money Concepts analysis results"
-    )
-    wyckoff: WyckoffAnalysis = Field(
-        ..., description="Wyckoff model state"
-    )
+    smc: SMCAnalysis = Field(..., description="Smart Money Concepts analysis results")
+    wyckoff: WyckoffAnalysis = Field(..., description="Wyckoff model state")
     microstructure: MicrostructureAnalysis = Field(
         ..., description="Order flow and microstructure metrics"
     )
-    harmonic: HarmonicResult = Field(
-        default_factory=HarmonicResult,
-        description="Harmonic pattern detection results",
-    )
     predictive_analysis: PredictiveAnalysisResult = Field(
-        ..., description="Aggregated predictive scoring and conflict detection results",
+        ...,
+        description="Aggregated predictive scoring and conflict detection results",
     )
     ispts_pipeline: ISPTSPipelineResult = Field(
-        ..., description="Outputs from each stage of the ISPTS pipeline",
+        ...,
+        description="Outputs from each stage of the ISPTS pipeline",
     )
     extras: Dict[str, Any] = Field(
         default_factory=dict,

--- a/services/enrichment/ispts_consumer.py
+++ b/services/enrichment/ispts_consumer.py
@@ -245,6 +245,9 @@ def main() -> None:
                     liquidity_engine=state.get("LiquidityEngine", {}),
                     structure_validator=state.get("StructureValidator", {}),
                     fvg_locator=state.get("FVGLocator", {}),
+                    harmonic_processor=HarmonicResult(
+                        **state.get("HarmonicProcessor", {})
+                    ),
                 )
 
                 ts = tick.get("ts") or tick.get("timestamp")
@@ -265,7 +268,6 @@ def main() -> None:
                     smc=SMCAnalysis(),
                     wyckoff=WyckoffAnalysis(),
                     microstructure=MicrostructureAnalysis(),
-                    harmonic=HarmonicResult(**state.get("HarmonicProcessor", {})),
                     predictive_analysis=predictive,
                     ispts_pipeline=pipeline_result,
                 )
@@ -280,9 +282,7 @@ def main() -> None:
                     timeframe=timeframe,
                 )
                 enriched_payloads_processed_total.inc()
-                processing_latency_seconds.observe(
-                    time.perf_counter() - start_time
-                )
+                processing_latency_seconds.observe(time.perf_counter() - start_time)
             consumer.commit(msg)
     finally:
         if producer is not None:
@@ -297,4 +297,3 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover - service entry point
     main()
-

--- a/tests/services/enrichment/test_ispts_consumer.py
+++ b/tests/services/enrichment/test_ispts_consumer.py
@@ -5,6 +5,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from pydantic import BaseModel
 
+
 # Stub out the broken `schemas` package with the minimal models required
 class AnalysisPayload(BaseModel):
     symbol: str
@@ -12,40 +13,57 @@ class AnalysisPayload(BaseModel):
     timestamp: int | float
     data: dict = {}
 
+
 class PredictiveScorerResult(BaseModel):
     maturity_score: float = 0.0
     grade: str | None = None
     confidence_factors: list = []
     extras: dict = {}
 
+
 class ConflictDetectionResult(BaseModel):
     is_conflict: bool
+
 
 class PredictiveAnalysisResult(BaseModel):
     scorer: PredictiveScorerResult
     conflict_detection: ConflictDetectionResult
+
 
 class ISPTSPipelineResult(BaseModel):
     context_analyzer: dict = {}
     liquidity_engine: dict = {}
     structure_validator: dict = {}
     fvg_locator: dict = {}
+    harmonic_processor: object = None
+
 
 class MarketContext(BaseModel):
     symbol: str
     timeframe: str
 
+
 class TechnicalIndicators(BaseModel):
     pass
+
 
 class SMCAnalysis(BaseModel):
     pass
 
+
 class WyckoffAnalysis(BaseModel):
     pass
 
+
 class MicrostructureAnalysis(BaseModel):
     pass
+
+
+class HarmonicResult(BaseModel):
+    harmonic_patterns: list = []
+    prz: dict = {}
+    confidence: float = 0.0
+
 
 class UnifiedAnalysisPayloadV1(BaseModel):
     symbol: str
@@ -58,12 +76,13 @@ class UnifiedAnalysisPayloadV1(BaseModel):
     microstructure: MicrostructureAnalysis
     predictive_analysis: PredictiveAnalysisResult
     ispts_pipeline: ISPTSPipelineResult
-    harmonic: dict = {}
+
 
 schemas_module = ModuleType("schemas")
 schemas_module.ISPTSPipelineResult = ISPTSPipelineResult
 schemas_module.MarketContext = MarketContext
 schemas_module.MicrostructureAnalysis = MicrostructureAnalysis
+schemas_module.HarmonicResult = HarmonicResult
 schemas_module.PredictiveAnalysisResult = PredictiveAnalysisResult
 schemas_module.SMCAnalysis = SMCAnalysis
 schemas_module.TechnicalIndicators = TechnicalIndicators
@@ -78,13 +97,19 @@ predictive_module.ConflictDetectionResult = ConflictDetectionResult
 predictive_module.PredictiveScorerResult = PredictiveScorerResult
 
 agent_profile_module = ModuleType("schemas.agent_profile_schemas")
+
+
 class PipelineConfig(BaseModel):
     stages: list[str] = []
+
+
 class SessionManifest(BaseModel):
     version: str = "1.0"
     instrument_pair: str
     timeframe: str
     topics: object
+
+
 agent_profile_module.PipelineConfig = PipelineConfig
 agent_profile_module.SessionManifest = SessionManifest
 
@@ -195,6 +220,7 @@ def test_stage_order_and_success_publishes_output(monkeypatch):
         def _stage(state):
             calls.append(name)
             return {"name": name}
+
         return _stage
 
     stage_map = {name: stage_factory(name) for name in stages}

--- a/tests/test_harmonic_unified_analysis.py
+++ b/tests/test_harmonic_unified_analysis.py
@@ -41,7 +41,7 @@ def test_build_unified_analysis_includes_harmonic():
         },
     }
     payload = ae.build_unified_analysis(tick, cfg)
-    harmonic = payload.harmonic
+    harmonic = payload.ispts_pipeline.harmonic_processor
     assert harmonic.harmonic_patterns[0]["pattern"] == "bat"
     assert harmonic.prz == {"low": 1.0, "high": 1.2}
     assert harmonic.confidence == 0.9

--- a/utils/analysis_engines.py
+++ b/utils/analysis_engines.py
@@ -66,13 +66,6 @@ def build_unified_analysis(
         conflict_detection=ConflictDetectionResult(is_conflict=False),
     )
 
-    pipeline = ISPTSPipelineResult(
-        context_analyzer={},
-        liquidity_engine={},
-        structure_validator={},
-        fvg_locator={},
-    )
-
     symbol = tick.get("symbol", "UNKNOWN")
     timeframe = tick.get("timeframe", "1m")
     ts = tick.get("ts") or tick.get("timestamp")
@@ -102,13 +95,11 @@ def build_unified_analysis(
         except Exception:
             pass
 
-    harmonic_data = (
-        tick.get("harmonic")
-        or tick.get("data", {}).get("harmonic")
-        or {}
-    )
+    harmonic_data = tick.get("harmonic") or tick.get("data", {}).get("harmonic") or {}
     if not harmonic_data:
-        patterns = tick.get("harmonic_patterns") or tick.get("data", {}).get("harmonic_patterns")
+        patterns = tick.get("harmonic_patterns") or tick.get("data", {}).get(
+            "harmonic_patterns"
+        )
         if patterns:
             harmonic_data["harmonic_patterns"] = patterns
     harmonic = HarmonicResult(**harmonic_data) if harmonic_data else HarmonicResult()
@@ -127,6 +118,14 @@ def build_unified_analysis(
         except Exception:
             pass
 
+    pipeline = ISPTSPipelineResult(
+        context_analyzer={},
+        liquidity_engine={},
+        structure_validator={},
+        fvg_locator={},
+        harmonic_processor=harmonic,
+    )
+
     return UnifiedAnalysisPayloadV1(
         symbol=symbol,
         timeframe=timeframe,
@@ -136,7 +135,6 @@ def build_unified_analysis(
         smc=smc,
         wyckoff=wyckoff,
         microstructure=MicrostructureAnalysis(),
-        harmonic=harmonic,
         predictive_analysis=predictive,
         ispts_pipeline=pipeline,
         extras={"risk": risk},


### PR DESCRIPTION
## Summary
- move harmonic output into ispts_pipeline.harmonic_processor
- update unified analysis builder and consumer to match new schema
- adjust tests for pipeline-based harmonic field

## Testing
- `pre-commit run --files schemas/payloads.py utils/analysis_engines.py services/enrichment/ispts_consumer.py tests/test_harmonic_unified_analysis.py tests/services/enrichment/test_ispts_consumer.py`
- `pytest`
- `pytest tests/test_harmonic_unified_analysis.py`
- `pytest tests/services/enrichment/test_ispts_consumer.py`
- `pytest tests/services/enrichment/test_handler_discord_alert.py`


------
https://chatgpt.com/codex/tasks/task_b_68c4e8a4df788328a6c1bc7afd481bcd