### PR TITLE
Combine os and json imports in pulse

### DIFF
--- a/dashboard/pages/pulse.py
+++ b/dashboard/pages/pulse.py
@@ -1,5 +1,4 @@
-import os
-import json
+import os, json
 from typing import Any, Dict, List, Optional
 
 import pandas as pd


### PR DESCRIPTION
## Summary
- Merge `os` and `json` imports into a single line in `dashboard/pages/pulse.py`

## Testing
- `python -m py_compile dashboard/pages/pulse.py`
- `python - <<'PY'
import importlib
try:
    importlib.import_module('dashboard.pages.pulse')
    print('import succeeded')
except Exception as e:
    print('import failed', e)
PY` *(fails: module 'streamlit' has no attribute 'experimental_singleton')*


------
https://chatgpt.com/codex/tasks/task_b_68c4e8a9c8e48328baa37af863291a03