### PR TITLE
Capture harmonic output in enrichment pipeline

### DIFF
--- a/services/enrichment/pipeline.py
+++ b/services/enrichment/pipeline.py
@@ -78,10 +78,11 @@ def run(
             before_keys = set(state.keys())
             state = runner(state, cfg)
             new_keys = set(state.keys()) - before_keys
-            module_output = {k: state[k] for k in new_keys}
             if name == "harmonic_processor" and "harmonic" in state:
-                module_output = state["harmonic"]
-            outputs[name] = module_output
+                outputs["harmonic_processor"] = state["harmonic"]
+            else:
+                module_output = {k: state[k] for k in new_keys}
+                outputs[name] = module_output
         except Exception as exc:  # pragma: no cover - safeguard
             state["status"] = "FAIL"
             state.setdefault("errors", {})[name] = str(exc)


### PR DESCRIPTION
## Summary
- ensure enrichment pipeline explicitly records harmonic analysis output
- verify no other modules write to `state['harmonic']`

## Testing
- `pre-commit run --files services/enrichment/pipeline.py`
- `pytest tests/test_enrichment_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4e8a90048832885fbb319d7e53e77