### PR TITLE
Aggregate harmonic processor results into unified HarmonicResult

### DIFF
--- a/docs/harmonic_patterns.md
+++ b/docs/harmonic_patterns.md
@@ -20,8 +20,9 @@ The detector recognises the following Fibonacci-based structures:
 
 ## Return schema
 
-`HarmonicProcessor.analyze` returns a dictionary containing
-`harmonic_patterns`, where each pattern entry has:
+`HarmonicProcessor.analyze` returns a dictionary with a ``harmonic`` key
+containing a :class:`~schemas.payloads.HarmonicResult`.  Each pattern
+entry within ``harmonic_patterns`` has:
 
 ```json
 {
@@ -32,9 +33,12 @@ The detector recognises the following Fibonacci-based structures:
 }
 ```
 
-`points` lists the five pivot locations forming the pattern. `prz`
-shows the potential reversal zone bounds, and `confidence` is a simple
-heuristic based on the number of recognised points.
+`points` lists the five pivot locations forming the pattern. ``prz``
+shows the potential reversal zone bounds, and ``confidence`` is a simple
+heuristic based on the number of recognised points.  The top-level
+``prz`` aggregates the minimum and maximum across all detected pattern
+points using ``{"low": min_price, "high": max_price}`` and ``confidence``
+summarises pattern confidence scores.
 
 ## Tolerance settings
 
@@ -66,8 +70,8 @@ bars = pd.DataFrame({
 
 proc = AdvancedProcessor()
 analysis = proc.process(bars)
-analysis.update(HarmonicProcessor().analyze(bars))
-print(analysis["harmonic_patterns"])  # list of detected patterns
+analysis["harmonic"] = HarmonicProcessor().analyze(bars)["harmonic"].model_dump()
+print(analysis["harmonic"]["harmonic_patterns"])  # list of detected patterns
 ```
 
 The combined `analysis` dictionary now includes harmonic pattern

--- a/services/enrichment/modules/harmonic_processor.py
+++ b/services/enrichment/modules/harmonic_processor.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 from core.harmonic_processor import HarmonicProcessor
 from enrichment.enrichment_engine import run_data_module
+from schemas.payloads import HarmonicResult
 
 
 def run(state: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
@@ -16,12 +17,15 @@ def run(state: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
         engine_factory=lambda: HarmonicProcessor(**config),
     )
     if state.get("status") != "FAIL":
-        result = {
-            "harmonic_patterns": state.get("harmonic_patterns", []),
-            "prz": state.get("prz", []),
-            "confidence": state.get("confidence", []),
-        }
-        state["HarmonicProcessor"] = result
+        harmonic = state.get("harmonic")
+        if isinstance(harmonic, HarmonicResult):
+            harmonic_dict = harmonic.model_dump()
+        elif isinstance(harmonic, dict):
+            harmonic_dict = harmonic
+        else:
+            harmonic_dict = {}
+        state["harmonic"] = harmonic_dict
+        state["HarmonicProcessor"] = harmonic_dict
     return state
 
 

--- a/tests/test_advanced_processor.py
+++ b/tests/test_advanced_processor.py
@@ -17,7 +17,11 @@ AdvancedProcessor = module.AdvancedProcessor
 
 def detect_harmonic_patterns(df: pd.DataFrame) -> dict:
     """Convenience wrapper for harmonic pattern analysis."""
-    return HarmonicProcessor().analyze(df)
+    result = HarmonicProcessor().analyze(df)
+    harmonic = result.get("harmonic")
+    if hasattr(harmonic, "model_dump"):
+        return harmonic.model_dump()
+    return harmonic
 
 
 def _generate_abcd_dataframe(bullish: bool = True) -> pd.DataFrame:
@@ -163,24 +167,24 @@ def test_elliott_wave_bearish_impulse():
 
 
 def test_elliott_wave_empty_dataframe():
-    df = pd.DataFrame(
-        columns=["open", "high", "low", "close"]
-    )
+    df = pd.DataFrame(columns=["open", "high", "low", "close"])
     processor = AdvancedProcessor(fractal_bars=1)
     result = processor.process(df, wave_only=True)
     assert result == {}
 
 
-@patch('utils.processors.advanced.AdvancedProcessor._llm_infer')
+@patch("utils.processors.advanced.AdvancedProcessor._llm_infer")
 def test_elliott_wave_llm_integration_mocked(mock_llm_infer, sample_df):
     mock_llm_infer.return_value = "Mocked LLM Forecast"
     processor = AdvancedProcessor(fractal_bars=1)
     result = processor.process(sample_df)
-    
+
     assert mock_llm_infer.called
     assert "ewt_forecast" in result
     assert result["ewt_forecast"] == "Mocked LLM Forecast"
-    assert result["elliott_wave"]["label"] == "impulse_bullish"  # Ensure elliott wave still processed
+    assert (
+        result["elliott_wave"]["label"] == "impulse_bullish"
+    )  # Ensure elliott wave still processed
 
 
 def test_detect_harmonic_patterns_bullish():


### PR DESCRIPTION
## Summary
- aggregate PRZ and confidence across detected harmonic patterns
- return HarmonicResult under `harmonic` and update enrichment module to merge it
- adjust tests and docs for new harmonic processor API

## Testing
- `pre-commit run --files core/harmonic_processor.py services/enrichment/modules/harmonic_processor.py tests/test_advanced_processor.py docs/harmonic_patterns.md`
- `pytest tests/test_advanced_processor.py::test_detect_harmonic_patterns_bullish tests/test_advanced_processor.py::test_detect_harmonic_patterns_bearish tests/test_advanced_processor.py::test_detect_harmonic_patterns_none`
- `pytest` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68c4e8a8e89483288e644778d80e288c