### PR TITLE
Use env vars for Pushover alerts

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -153,6 +153,12 @@ DISCORD_WEBHOOK_URL=your_discord_webhook_url_here
 SLACK_WEBHOOK_URL=your_slack_webhook_url_here
 
 # -----------------------------------------------------------------------------
+# PUSHOVER NOTIFICATIONS (Optional)
+# -----------------------------------------------------------------------------
+PUSHOVER_TOKEN=your_pushover_app_token_here
+PUSHOVER_USER_KEY=your_pushover_user_key_here
+
+# -----------------------------------------------------------------------------
 # TELEGRAM NOTIFICATIONS (Legacy - Optional)
 # -----------------------------------------------------------------------------
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here

--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -13,6 +13,7 @@
 
 - Ensure `DJANGO_SECRET_KEY` only set once with default fallback
 - Provide `SLACK_WEBHOOK_URL` in the environment for Alertmanager Slack alerts
+- Provide `PUSHOVER_TOKEN` and `PUSHOVER_USER_KEY` in the environment for Pushover notifications
 - Celery/Celery Beat:
   - `entrypoint`: `celery -A app worker|beat`
   - `PYTHONPATH` includes: `/app/backend/django:/app/agents:/app:/app/components:/app/utils:/app/backend`

--- a/docs/env-reference.md
+++ b/docs/env-reference.md
@@ -146,6 +146,14 @@ Environment variable used for Alertmanager Slack integration.
 | --- | --- | --- | --- |
 | `SLACK_WEBHOOK_URL` | _(empty)_ | Provide to enable Slack alert delivery. | Incoming webhook URL for Slack alerts. |
 
+## Pushover Notifications
+Environment variables used for Alertmanager Pushover integration.
+
+| Variable | Default | Override Behavior | Purpose |
+| --- | --- | --- | --- |
+| `PUSHOVER_TOKEN` | _(empty)_ | Provide to enable Pushover alerts. | Pushover application token. |
+| `PUSHOVER_USER_KEY` | _(empty)_ | Provide to enable Pushover alerts. | Pushover user key receiving notifications. |
+
 ## Alert Settings
 | Variable | Default | Override Behavior | Purpose |
 | --- | --- | --- | --- |

--- a/docs/full-setup-guide.md
+++ b/docs/full-setup-guide.md
@@ -24,6 +24,7 @@ cp .env.template .env
 
 Ensure `POSTGRES_PASSWORD` is set to a strong value; the stack will not start without it.
 Optionally set `SLACK_WEBHOOK_URL` to route Alertmanager notifications to Slack.
+Optionally set `PUSHOVER_TOKEN` and `PUSHOVER_USER_KEY` to enable Pushover alert delivery.
 
 ## 3. Configure domain records
 

--- a/monitoring/configs/alertmanager/alertmanager-pushover-config.yml
+++ b/monitoring/configs/alertmanager/alertmanager-pushover-config.yml
@@ -44,8 +44,8 @@ route:
 receivers:
   - name: 'default-pushover'
     pushover_configs:
-      - token: xxxxxxxxxxxxxxxxxxxxxxxxx
-        user_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - token: '${PUSHOVER_TOKEN}'
+        user_key: '${PUSHOVER_USER_KEY}'
         title: '{{ template "pushover.default.title" . }}'
         message: '{{ template "pushover.default.message" . }}'
         url: '{{ template "pushover.default.url" . }}'
@@ -53,8 +53,8 @@ receivers:
 
   - name: 'warning-pushover'
     pushover_configs:
-      - token: xxxxxxxxxxxxxxxxxxxxxxxxx
-        user_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - token: '${PUSHOVER_TOKEN}'
+        user_key: '${PUSHOVER_USER_KEY}'
         title: '[{{ .Status | toUpper }}] {{ .CommonAnnotations.title }}'
         message: '{{ .CommonAnnotations.description }}'
         url: '{{ template "pushover.default.url" . }}'
@@ -62,8 +62,8 @@ receivers:
 
   - name: 'critical-pushover'
     pushover_configs:
-      - token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        user_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      - token: '${PUSHOVER_TOKEN}'
+        user_key: '${PUSHOVER_USER_KEY}'
         title: '{{ if eq .Status "firing" }}ALARM{{ else }}OK{{ end }} [{{ .Status | toUpper }}] {{ .CommonAnnotations.summary }}'
         message: '{{ template "pushover.default.message" . }}'
         url: '{{ template "pushover.default.url" . }}'


### PR DESCRIPTION
## Summary
- Replace hardcoded Pushover tokens with `${PUSHOVER_TOKEN}` and `${PUSHOVER_USER_KEY}` in Alertmanager config
- Document Pushover environment variables in deployment guides and env reference
- Add Pushover variables to `.env.template`

## Testing
- `pre-commit run --files monitoring/configs/alertmanager/alertmanager-pushover-config.yml .env.template docs/DEPLOYMENT_CHECKLIST.md docs/full-setup-guide.md docs/env-reference.md`
- `pytest -q` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68c4e8b481908328b4218183fe6373d9