### PR TITLE
Add unit tests for Wyckoff detectors

### DIFF
--- a/dashboard/_mix/5_  🧠 SMC & WYCKOFF.py
+++ b/dashboard/_mix/5_  🧠 SMC & WYCKOFF.py
@@ -1,8 +1,9 @@
 """QRT dashboard blending smart‑money concepts with Wyckoff analysis.
 
-This module backs an interactive Streamlit dashboard but also exposes a small
-collection of detection heuristics for unit testing.  The following Wyckoff
-events are recognised using straightforward logic:
+Beyond powering an interactive Streamlit dashboard, this module exposes a
+handful of self‑contained detection heuristics that can be imported and tested
+independently.  The following Wyckoff events are recognised using
+straightforward logic:
 
 * **Selling climax** – new low on a sharp drop and volume spike.
 * **Accumulation range** – contraction in price range accompanied by lower
@@ -10,10 +11,11 @@ events are recognised using straightforward logic:
 * **Spring** – temporary break of support that closes back above it.
 * **Markup beginning** – breakout above resistance with expanding volume.
 
-These detectors are intentionally lightweight yet fully functional and are
-covered by unit tests.  More sophisticated analytics (for example the
-``TiquidityEngine``) are outside the scope of this module and raise
-``NotImplementedError`` when invoked.
+Each detector lives on :class:`QRTQuantumAnalyzer` as a private method.  They
+are intentionally lightweight yet fully functional and are now covered by unit
+tests.  More sophisticated analytics (for example the ``TiquidityEngine``)
+remain out of scope for this module and raise ``NotImplementedError`` when
+invoked.
 """
 
 import streamlit as st

--- a/tests/test_smc_wyckoff_detectors.py
+++ b/tests/test_smc_wyckoff_detectors.py
@@ -1,0 +1,71 @@
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from typing import Dict, Optional
+
+# Load only the class definitions needed for testing without executing
+# the dashboard code that follows in the original module.
+def load_analyzer():
+    module_path = Path(__file__).resolve().parents[1] / "dashboard/_mix/5_  🧠 SMC & WYCKOFF.py"
+    code = module_path.read_text(encoding="utf-8")
+    start = code.index("class QRTQuantumAnalyzer")
+    end = code.index("# =================== END QRT ANALYZER DEFINITIONS =====================")
+    snippet = code[start:end]
+
+    class QuantumMicrostructureAnalyzer:
+        def __init__(self, config_path: str):
+            self.config_path = config_path
+            self.session_state = {}
+
+    globals_dict = {
+        "pd": pd,
+        "np": np,
+        "Dict": Dict,
+        "Optional": Optional,
+        "QuantumMicrostructureAnalyzer": QuantumMicrostructureAnalyzer,
+    }
+    # Execute the snippet using a single namespace so classes can reference
+    # each other (e.g. ``TiquidityEngine`` used inside ``QRTQuantumAnalyzer``).
+    exec(snippet, globals_dict, globals_dict)
+    return globals_dict["QRTQuantumAnalyzer"]
+
+Analyzer = load_analyzer()
+
+
+def test_detect_selling_climax():
+    analyzer = Analyzer("cfg")
+    df = pd.DataFrame({
+        "close": [100, 98, 97, 95, 90],
+        "low": [99, 97, 96, 94, 89],
+        "volume": [1000, 1100, 1200, 1300, 4000],
+    })
+    assert analyzer._detect_selling_climax(df)
+
+
+def test_detect_accumulation_range():
+    analyzer = Analyzer("cfg")
+    df = pd.DataFrame({
+        "high": [10, 12, 13, 14, 15] + [10.5] * 20,
+        "low": [5, 6, 7, 8, 9] + [9.5] * 20,
+        "volume": [1000] * 5 + [100] * 20,
+    })
+    assert analyzer._detect_accumulation_range(df)
+
+
+def test_detect_spring():
+    analyzer = Analyzer("cfg")
+    df = pd.DataFrame({
+        "low": [10, 9, 8, 7, 6, 4, 3, 8],
+        "close": [10, 9, 8, 7, 6, 4, 5, 9],
+    })
+    assert analyzer._detect_spring(df) == 6
+
+
+def test_detect_markup_beginning():
+    analyzer = Analyzer("cfg")
+    df = pd.DataFrame({
+        "high": [10, 10.5, 10.8, 10.7, 10.9, 11.5],
+        "close": [10, 10.3, 10.7, 10.6, 10.8, 11.6],
+        "volume": [100, 120, 110, 115, 130, 300],
+    })
+    assert analyzer._detect_markup_beginning(df)


### PR DESCRIPTION
## Summary
- document standalone Wyckoff detection heuristics in mixed dashboard module
- add tests covering selling climax, accumulation range, spring, and markup logic

## Testing
- `pytest tests/test_smc_wyckoff_detectors.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68c4e8b3e5cc8328944e2511bab719a1