### PR TITLE
Use UUID identifiers for Qdrant points and document ID storage

### DIFF
--- a/docs/vectorization_service.md
+++ b/docs/vectorization_service.md
@@ -68,4 +68,5 @@ Configuration for Qdrant is provided via environment variables:
 }
 ```
 
-The vector store receives the payload via an HTTP `POST` to `${QDRANT_URL}/upsert` with the JSON body above.
+The vector store receives the payload via an HTTP `POST` to `${QDRANT_URL}/upsert` with the JSON body above. Qdrant returns the
+ID associated with each point; store or log this identifier for later retrieval.

--- a/services/enrichment/modules/harmonic_processor.py
+++ b/services/enrichment/modules/harmonic_processor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import uuid
 from typing import Any, Dict, List
 
 from qdrant_client import QdrantClient
@@ -24,7 +25,10 @@ def _pattern_to_text(pattern: Dict[str, Any]) -> str:
 
 
 def run(state: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
-    """Populate ``state`` with harmonic pattern analysis and upload vectors."""
+    """Populate ``state`` with harmonic pattern analysis and upload vectors.
+
+    The generated Qdrant IDs should be stored or logged for later retrieval.
+    """
 
 
     state = run_data_module(
@@ -50,7 +54,8 @@ def run(state: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
 
     vectors = [embed(_pattern_to_text(p)) for p in patterns]
     payloads = [{k: v for k, v in p.items() if k != "points"} for p in patterns]
-    ids = list(range(len(patterns)))
+    ids = [str(uuid.uuid4()) for _ in patterns]
+    # Store or log these IDs so the vectors can be retrieved later from Qdrant
 
     url = os.getenv("QDRANT_URL", "http://localhost:6333")
     api_key = os.getenv("QDRANT_API_KEY")

--- a/utils/harmonic_embeddings.py
+++ b/utils/harmonic_embeddings.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import uuid
 from typing import Any, Dict, Iterable, List
 
 from qdrant_client import QdrantClient
@@ -43,6 +44,8 @@ async def upsert_harmonic_patterns(
 ) -> None:
     """Embed and upsert harmonic patterns into a Qdrant collection.
 
+    The generated point IDs should be stored or logged for later retrieval.
+
     Parameters
     ----------
     patterns:
@@ -65,13 +68,14 @@ async def upsert_harmonic_patterns(
 
     vectors: List[List[float]] = []
     payloads: List[Dict[str, Any]] = []
-    ids: List[int] = []
+    ids: List[str] = []
 
-    for idx, pattern in enumerate(patterns):
+    for pattern in patterns:
         text = _pattern_to_text(pattern)
         vectors.append(embed(text))
         payloads.append({k: v for k, v in pattern.items() if k != "points"})
-        ids.append(idx)
+        ids.append(str(uuid.uuid4()))
+        # Record these IDs to reference the vectors in future queries
 
     if vectors:
         await processor.upsert(vectors, payloads, ids)

--- a/utils/processors/harmonic.py
+++ b/utils/processors/harmonic.py
@@ -45,7 +45,7 @@ class HarmonicStorageProcessor:
         self,
         vectors: Sequence[Sequence[float]],
         payloads: Iterable[dict],
-        ids: Iterable[int],
+        ids: Iterable[str | int],
     ) -> None:
         """Insert vectors into Qdrant asynchronously.
 
@@ -53,10 +53,20 @@ class HarmonicStorageProcessor:
         client. Synchronous clients are executed in a background thread via
         :func:`asyncio.to_thread`, mirroring patterns used in other asynchronous
         utilities.
+
+        Parameters
+        ----------
+        vectors:
+            Sequence of vectors to persist.
+        payloads:
+            Iterable of payload dictionaries for each vector.
+        ids:
+            Iterable of unique identifiers. These IDs are sent to Qdrant and
+            should be stored or logged for later retrieval.
         """
 
         points = [
-            models.PointStruct(id=pid, vector=vec, payload=payload)
+            models.PointStruct(id=str(pid), vector=vec, payload=payload)
             for pid, vec, payload in zip(ids, vectors, payloads)
         ]
         if self._is_async:


### PR DESCRIPTION
## Summary
- Switch harmonic pattern uploads to Qdrant to use `uuid.uuid4()` IDs instead of numeric enumeration
- Cast point IDs to strings when constructing Qdrant `PointStruct` objects
- Document that returned IDs should be stored or logged for later retrieval

## Testing
- `pytest tests/test_harmonic_embeddings.py -q`
- `pytest tests/test_harmonic_module_upload.py::test_upload -q` *(fails: SyntaxError in services.enrichment.modules.__init__)*

------
https://chatgpt.com/codex/tasks/task_b_68c4ebc69b048328a8db7f558c2f777e