### PR TITLE
feat: support async qdrant clients

### DIFF
--- a/services/enrichment/modules/harmonic_processor.py
+++ b/services/enrichment/modules/harmonic_processor.py
@@ -11,7 +11,7 @@ from qdrant_client import QdrantClient
 from core.harmonic_processor import HarmonicProcessor as PatternAnalyzer
 from enrichment.enrichment_engine import run_data_module
 from services.mcp2.vector.embeddings import embed
-from utils.processors.harmonic import HarmonicProcessor as QdrantUploader
+from utils.processors.harmonic import HarmonicVectorStore as QdrantUploader
 
 
 def _pattern_to_text(pattern: Dict[str, Any]) -> str:

--- a/tests/test_harmonic_storage_processor.py
+++ b/tests/test_harmonic_storage_processor.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils.processors.harmonic import HarmonicStorageProcessor
+from utils.processors.harmonic import HarmonicVectorStore
 
 
 class DummySyncClient:
@@ -22,8 +22,8 @@ class DummyAsyncClient:
 @pytest.mark.asyncio
 async def test_upsert_uses_background_thread_for_sync_client():
     client = DummySyncClient()
-    processor = HarmonicStorageProcessor(client)
-    await processor.upsert([[0.1]], [{}], [1])
+    store = HarmonicVectorStore(client)
+    await store.upsert([[0.1]], [{}], [1])
 
     assert client.called
 
@@ -31,6 +31,6 @@ async def test_upsert_uses_background_thread_for_sync_client():
 @pytest.mark.asyncio
 async def test_upsert_awaits_async_client():
     client = DummyAsyncClient()
-    processor = HarmonicStorageProcessor(client)
-    await processor.upsert([[0.1]], [{}], [1])
+    store = HarmonicVectorStore(client)
+    await store.upsert([[0.1]], [{}], [1])
     assert client.called

--- a/utils/harmonic_embeddings.py
+++ b/utils/harmonic_embeddings.py
@@ -1,11 +1,10 @@
 """Embed harmonic pattern features and store them asynchronously in Qdrant.
 
 This module previously handled Qdrant upserts directly.  It now delegates the
-storage operation to :class:`utils.processors.harmonic.HarmonicStorageProcessor`
-which
-provides an awaitable interface capable of working with both synchronous and
-asynchronous Qdrant clients.  The public API is kept as a thin async wrapper so
-existing call sites can simply ``await`` the new implementation.
+storage operation to :class:`utils.processors.harmonic.HarmonicVectorStore`
+which provides an awaitable interface capable of working with both synchronous
+and asynchronous Qdrant clients.  The public API is kept as a thin async wrapper
+so existing call sites can simply ``await`` the new implementation.
 """
 
 from __future__ import annotations
@@ -14,9 +13,9 @@ import asyncio
 import os
 from typing import Any, Dict, Iterable, List
 
-from qdrant_client import QdrantClient
+from qdrant_client import AsyncQdrantClient, QdrantClient
 
-from utils.processors.harmonic import HarmonicStorageProcessor
+from utils.processors.harmonic import HarmonicVectorStore
 
 try:  # pragma: no cover - best effort fallback when deps missing
     from services.mcp2.vector.embeddings import embed
@@ -38,7 +37,7 @@ def _pattern_to_text(pattern: Dict[str, Any]) -> str:
 async def upsert_harmonic_patterns(
     patterns: Iterable[Dict[str, Any]],
     *,
-    client: QdrantClient | None = None,
+    client: QdrantClient | AsyncQdrantClient | None = None,
     collection_name: str = "harmonic_patterns",
 ) -> None:
     """Embed and upsert harmonic patterns into a Qdrant collection.
@@ -61,7 +60,7 @@ async def upsert_harmonic_patterns(
         api_key = os.getenv("QDRANT_API_KEY")
         client = QdrantClient(url=url, api_key=api_key)
 
-    processor = HarmonicStorageProcessor(client, collection_name)
+    store = HarmonicVectorStore(client, collection_name)
 
     vectors: List[List[float]] = []
     payloads: List[Dict[str, Any]] = []
@@ -74,13 +73,13 @@ async def upsert_harmonic_patterns(
         ids.append(idx)
 
     if vectors:
-        await processor.upsert(vectors, payloads, ids)
+        await store.upsert(vectors, payloads, ids)
 
 
 def upsert_harmonic_patterns_sync(
     patterns: Iterable[Dict[str, Any]],
     *,
-    client: QdrantClient | None = None,
+    client: QdrantClient | AsyncQdrantClient | None = None,
     collection_name: str = "harmonic_patterns",
 ) -> None:
     """Synchronous wrapper around :func:`upsert_harmonic_patterns`.

--- a/utils/processors/harmonic.py
+++ b/utils/processors/harmonic.py
@@ -1,6 +1,6 @@
 """Asynchronous Qdrant storage for harmonic pattern vectors.
 
-This module provides :class:`HarmonicStorageProcessor`, an awaitable helper for
+This module provides :class:`HarmonicVectorStore`, an awaitable helper for
 persisting harmonic pattern embeddings.  It focuses solely on Qdrant upserts
 and intentionally avoids the pattern *analysis* performed by
 ``core.harmonic_processor.HarmonicProcessor``.
@@ -18,14 +18,18 @@ import asyncio
 import inspect
 from typing import Iterable, Sequence
 
-from qdrant_client import models
+from qdrant_client import AsyncQdrantClient, QdrantClient, models
 
 
-class HarmonicStorageProcessor:
+class HarmonicVectorStore:
     """Processor responsible for persisting harmonic pattern vectors."""
 
 
-    def __init__(self, client: object, collection_name: str = "harmonic") -> None:
+    def __init__(
+        self,
+        client: QdrantClient | AsyncQdrantClient,
+        collection_name: str = "harmonic",
+    ) -> None:
         """Initialize the processor with a Qdrant client.
 
         Parameters
@@ -69,4 +73,8 @@ class HarmonicStorageProcessor:
             )
 
 
-__all__ = ["HarmonicStorageProcessor"]
+# Backwards compatibility alias
+HarmonicStorageProcessor = HarmonicVectorStore
+
+
+__all__ = ["HarmonicVectorStore", "HarmonicStorageProcessor"]


### PR DESCRIPTION
## Summary
- allow HarmonicVectorStore to accept both synchronous and asynchronous Qdrant clients
- type hint client parameters with `QdrantClient | AsyncQdrantClient | None`
- rename storage helper to `HarmonicVectorStore` and update tests

## Testing
- `pytest tests/test_harmonic_embeddings.py tests/test_harmonic_storage_processor.py`
- `pytest tests/test_harmonic_module_upload.py` *(fails: SyntaxError in services.enrichment.modules.__init__)*

------
https://chatgpt.com/codex/tasks/task_b_68c4ebc77fac83288fedc1296a4ce4b4