### PR TITLE
feat: add vectorized enrichment config

### DIFF
--- a/config/enrichment_vectorized.yaml
+++ b/config/enrichment_vectorized.yaml
@@ -1,0 +1,16 @@
+# Vectorized enrichment configuration with per-module toggles.
+vectorized:
+  smc: true
+  poi: true
+  divergence: true
+  rsi_fusion: true
+
+advanced:
+  harmonic:
+    enabled: false
+
+vector_db:
+  collection: enrichment_vectors
+
+embedding:
+  model: text-embedding-3-small

--- a/utils/enrichment_config.py
+++ b/utils/enrichment_config.py
@@ -13,7 +13,7 @@ under the ``config`` mapping of each subgroup if needed.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, List
 
 import yaml
 from pydantic import BaseModel, Field, field_validator
@@ -124,6 +124,15 @@ class HarmonicConfig(BaseModel):
     upload: bool = False
 
 
+class VectorizedConfig(BaseModel):
+    """Toggles for vectorized enrichment modules."""
+
+    smc: bool = True
+    poi: bool = True
+    divergence: bool = True
+    rsi_fusion: bool = True
+
+
 class VectorDBConfig(BaseModel):
     """Settings for the backing vector database."""
 
@@ -159,6 +168,7 @@ class EnrichmentConfig(BaseModel):
     technical: TechnicalConfig = TechnicalConfig()
     structure: StructureConfig = StructureConfig()
     advanced: AdvancedConfig = AdvancedConfig()
+    vectorized: VectorizedConfig = Field(default_factory=VectorizedConfig)
     vector_db: VectorDBConfig = Field(default_factory=VectorDBConfig)
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
 
@@ -197,6 +207,10 @@ class EnrichmentConfig(BaseModel):
                 "tolerance": self.advanced.harmonic.tolerance,
                 "window": self.advanced.harmonic.window,
             },
+            "smc": {"enabled": self.vectorized.smc},
+            "poi": {"enabled": self.vectorized.poi},
+            "divergence": {"enabled": self.vectorized.divergence},
+            "rsi_fusion": {"enabled": self.vectorized.rsi_fusion},
         }
 
 
@@ -242,6 +256,7 @@ __all__ = [
     "AlligatorConfig",
     "ElliottConfig",
     "HarmonicConfig",
+    "VectorizedConfig",
     "VectorDBConfig",
     "EmbeddingConfig",
     "AdvancedConfig",


### PR DESCRIPTION
## Summary
- extend enrichment config models with vectorized module toggles
- add configuration file enabling vectorized enrichment modules

## Testing
- `pytest -q` *(fails: missing pyarrow and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68c4fc77732c83289b74bed799d2a818