### PR TITLE
Add vector-aware enrichment modules

### DIFF
--- a/config/enrichment_default.yaml
+++ b/config/enrichment_default.yaml
@@ -28,6 +28,10 @@ advanced:
   predictive_scorer: true
   fractal_detector: true
   fractal_bars: 2
+  smc: false
+  poi: false
+  divergence: false
+  rsi_fusion: false
   harmonic:
     enabled: true
     collection: harmonic_patterns

--- a/services/enrichment/modules/__init__.py
+++ b/services/enrichment/modules/__init__.py
@@ -15,6 +15,10 @@ from . import fvg_locator as fvg
 from . import liquidity_engine as liquidity
 from . import predictive_scorer
 from . import structure_validator
+from . import smc
+from . import poi
+from . import divergence
+from . import rsi_fusion
 
 # Register shorthand aliases so callers can refer to modules by logical name.
 sys.modules[__name__ + ".context"] = context
@@ -27,4 +31,8 @@ __all__ = [
     "liquidity",
     "predictive_scorer",
     "structure_validator",
+    "smc",
+    "poi",
+    "divergence",
+    "rsi_fusion",
 ]

--- a/services/enrichment/modules/divergence.py
+++ b/services/enrichment/modules/divergence.py
@@ -1,0 +1,40 @@
+"""Price/volume divergence vector enrichment module."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from enrichment.enrichment_engine import ensure_dataframe
+
+
+def run(state: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+    """Compute a simple divergence vector between price and volume changes.
+
+    The vector contains the last five differences between percentage changes
+    in closing price and volume. This representation can be stored in a
+    vector database when ``config['upload']`` is enabled.
+    """
+
+    df = ensure_dataframe(state, {"close", "volume"})
+    if df is None or len(df) < 2:
+        return state
+
+    pct_price = df["close"].pct_change()
+    pct_vol = df["volume"].pct_change()
+    divergence = (pct_price - pct_vol).fillna(0.0)
+    vector = divergence.tail(5).astype(float).tolist()
+    state["divergence_vector"] = vector
+
+    if config.get("upload"):
+        try:  # pragma: no cover - optional dependency
+            from analytics.vector_db_config import add_vectors
+
+            add_vectors([vector], [config.get("id", "divergence")], [config.get("metadata", {})])
+        except Exception:
+            pass
+
+    state.setdefault("status", "PASS")
+    return state
+
+
+__all__ = ["run"]

--- a/services/enrichment/modules/poi.py
+++ b/services/enrichment/modules/poi.py
@@ -1,0 +1,43 @@
+"""Point of Interest vector enrichment module."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from enrichment.enrichment_engine import ensure_dataframe
+
+
+def run(state: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+    """Identify key price/volume locations and store them as a vector.
+
+    The vector captures the highest high, lowest low and average volume over
+    the last ten rows. When ``config['upload']`` is true the vector will also
+    be forwarded to the configured vector database.
+    """
+
+    df = ensure_dataframe(state, {"high", "low", "volume"})
+    if df is None:
+        return state
+
+    window = int(config.get("window", 10))
+    recent = df.tail(window)
+    vector = [
+        float(recent["high"].max()),
+        float(recent["low"].min()),
+        float(recent["volume"].mean()),
+    ]
+    state["poi_vector"] = vector
+
+    if config.get("upload"):
+        try:  # pragma: no cover - optional dependency
+            from analytics.vector_db_config import add_vectors
+
+            add_vectors([vector], [config.get("id", "poi")], [config.get("metadata", {})])
+        except Exception:
+            pass
+
+    state.setdefault("status", "PASS")
+    return state
+
+
+__all__ = ["run"]

--- a/services/enrichment/modules/rsi_fusion.py
+++ b/services/enrichment/modules/rsi_fusion.py
@@ -1,0 +1,50 @@
+"""RSI fusion vector enrichment module."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pandas as pd
+
+from enrichment.enrichment_engine import ensure_dataframe
+
+
+def _rsi(series: pd.Series, period: int) -> pd.Series:
+    """Return a simple Relative Strength Index series."""
+
+    delta = series.diff()
+    gain = delta.where(delta > 0, 0.0)
+    loss = -delta.where(delta < 0, 0.0)
+    avg_gain = gain.rolling(period).mean()
+    avg_loss = loss.rolling(period).mean()
+    rs = avg_gain / avg_loss.replace(0, pd.NA)
+    return 100 - (100 / (1 + rs))
+
+
+def run(state: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+    """Fuse RSI statistics into a compact vector for downstream models."""
+
+    df = ensure_dataframe(state, {"close"})
+    if df is None:
+        return state
+
+    period = int(config.get("period", 14))
+    rsi_series = _rsi(df["close"], period).fillna(0.0)
+    last = float(rsi_series.iloc[-1]) if not rsi_series.empty else 0.0
+    mean = float(rsi_series.tail(period).mean()) if not rsi_series.empty else 0.0
+    vector = [last, mean]
+    state["rsi_fusion_vector"] = vector
+
+    if config.get("upload"):
+        try:  # pragma: no cover - optional dependency
+            from analytics.vector_db_config import add_vectors
+
+            add_vectors([vector], [config.get("id", "rsi_fusion")], [config.get("metadata", {})])
+        except Exception:
+            pass
+
+    state.setdefault("status", "PASS")
+    return state
+
+
+__all__ = ["run"]

--- a/services/enrichment/modules/smc.py
+++ b/services/enrichment/modules/smc.py
@@ -1,0 +1,44 @@
+"""Smart Money Concepts vector enrichment module."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from enrichment.enrichment_engine import ensure_dataframe
+
+
+def run(state: Dict[str, Any], config: Dict[str, Any]) -> Dict[str, Any]:
+    """Derive a simple price/volume vector representing market structure.
+
+    The function extracts the latest OHLCV values as a small numeric vector.
+    When ``config['upload']`` is truthy the vector is also forwarded to the
+    configured vector store.  This keeps the module light-weight while still
+    being compatible with downstream vector databases.
+    """
+
+    df = ensure_dataframe(state, {"open", "high", "low", "close"})
+    if df is None:
+        return state
+    last = df.iloc[-1]
+    vector = [
+        float(last.get("open", 0.0)),
+        float(last.get("high", 0.0)),
+        float(last.get("low", 0.0)),
+        float(last.get("close", 0.0)),
+        float(last.get("volume", 0.0)),
+    ]
+    state["smc_vector"] = vector
+
+    if config.get("upload"):
+        try:  # pragma: no cover - optional dependency
+            from analytics.vector_db_config import add_vectors
+
+            add_vectors([vector], [config.get("id", "smc")], [config.get("metadata", {})])
+        except Exception:
+            pass
+
+    state.setdefault("status", "PASS")
+    return state
+
+
+__all__ = ["run"]

--- a/services/enrichment/pipeline.py
+++ b/services/enrichment/pipeline.py
@@ -31,6 +31,10 @@ MODULE_ORDER: Iterable[str] = (
     "fvg_locator",
     "harmonic_processor",
     "predictive_scorer",
+    "smc",
+    "poi",
+    "divergence",
+    "rsi_fusion",
 )
 
 

--- a/utils/enrichment_config.py
+++ b/utils/enrichment_config.py
@@ -147,6 +147,10 @@ class AdvancedConfig(BaseModel):
     predictive_scorer: bool = True
     fractal_detector: bool = True
     fractal_bars: int = 2
+    smc: bool = False
+    poi: bool = False
+    divergence: bool = False
+    rsi_fusion: bool = False
     alligator: AlligatorConfig = Field(default_factory=AlligatorConfig)
     elliott: ElliottConfig = Field(default_factory=ElliottConfig)
     harmonic: HarmonicConfig = Field(default_factory=HarmonicConfig)
@@ -197,6 +201,10 @@ class EnrichmentConfig(BaseModel):
                 "tolerance": self.advanced.harmonic.tolerance,
                 "window": self.advanced.harmonic.window,
             },
+            "smc": {"enabled": self.advanced.smc},
+            "poi": {"enabled": self.advanced.poi},
+            "divergence": {"enabled": self.advanced.divergence},
+            "rsi_fusion": {"enabled": self.advanced.rsi_fusion},
         }
 
 


### PR DESCRIPTION
## Summary
- Implement SMC, POI, divergence and RSI-fusion enrichment modules with vector outputs
- Expose new modules through pipeline and configuration so each can be individually toggled
- Extend default enrichment config to include corresponding advanced toggles

## Testing
- `pytest` *(fails: populate() isn't reentrant and other collection errors)*
- `pytest tests/test_enrichment_pipeline.py` *(fails: predictive scorer raises '>' not supported between NoneType and int)*

------
https://chatgpt.com/codex/tasks/task_b_68c4fc742bc48328989e33a1d3108369