### PR TITLE
Add vector backtester utility

### DIFF
--- a/tests/test_vector_backtester.py
+++ b/tests/test_vector_backtester.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+import pytest
+
+from utils import vector_backtester
+from utils.vector_backtester import score_embedding
+
+
+def test_score_embedding_returns_metrics(monkeypatch):
+    instances = {}
+
+    class DummyClient:
+        def __init__(self, url=None, api_key=None):
+            instances['url'] = url
+            instances['api_key'] = api_key
+
+        def search(self, **kwargs):
+            instances['search_kwargs'] = kwargs
+            return [
+                SimpleNamespace(payload={'pnl': 1.0, 'outcome': True}),
+                SimpleNamespace(payload={'pnl': -0.5, 'outcome': False}),
+            ]
+
+    monkeypatch.setenv('QDRANT_URL', 'http://localhost')
+    monkeypatch.setenv('QDRANT_API_KEY', 'token')
+    monkeypatch.setenv('QDRANT_COLLECTION', 'testcol')
+    monkeypatch.setattr(vector_backtester, 'QdrantClient', DummyClient)
+
+    avg_pnl, win_rate, payloads = score_embedding([0.1, 0.2])
+
+    assert instances['url'] == 'http://localhost'
+    assert instances['api_key'] == 'token'
+    assert instances['search_kwargs']['collection_name'] == 'testcol'
+    assert instances['search_kwargs']['query_vector'] == [0.1, 0.2]
+    assert avg_pnl == pytest.approx(0.25)
+    assert win_rate == pytest.approx(0.5)
+    assert payloads == [
+        {'pnl': 1.0, 'outcome': True},
+        {'pnl': -0.5, 'outcome': False},
+    ]
+
+
+def test_score_embedding_handles_errors(monkeypatch):
+    class FailingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def search(self, **kwargs):  # pragma: no cover - behavior validation
+            raise RuntimeError('boom')
+
+    monkeypatch.setattr(vector_backtester, 'QdrantClient', FailingClient)
+
+    avg_pnl, win_rate, payloads = score_embedding([1.0])
+
+    assert (avg_pnl, win_rate, payloads) == (0.0, 0.0, [])

--- a/utils/vector_backtester.py
+++ b/utils/vector_backtester.py
@@ -1,0 +1,72 @@
+import logging
+import os
+from typing import List, Tuple, Dict, Any
+
+try:
+    from qdrant_client import QdrantClient  # type: ignore
+except Exception:  # ImportError or any other
+    QdrantClient = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+def score_embedding(embedding: List[float]) -> Tuple[float, float, List[Dict[str, Any]]]:
+    """Score an embedding against analogs stored in Qdrant.
+
+    Parameters
+    ----------
+    embedding : List[float]
+        The vector representation of the tick to evaluate.
+
+    Returns
+    -------
+    Tuple[float, float, List[dict]]
+        Average PnL, win rate, and the payloads from the retrieved analogs.
+        If Qdrant is unreachable or the client is unavailable, zeros and an
+        empty list are returned.
+    """
+
+    if QdrantClient is None:
+        logger.warning("Qdrant client library not available")
+        return 0.0, 0.0, []
+
+    url = os.getenv("QDRANT_URL")
+    api_key = os.getenv("QDRANT_API_KEY")
+    collection = os.getenv("QDRANT_COLLECTION", "enriched")
+
+    try:
+        client = QdrantClient(url=url, api_key=api_key)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Failed to initialize QdrantClient: %s", exc)
+        return 0.0, 0.0, []
+
+    try:
+        results = client.search(
+            collection_name=collection,
+            query_vector=embedding,
+            limit=10,
+            with_payload=True,
+            with_vectors=False,
+        )
+    except Exception as exc:
+        logger.error("Qdrant search failed: %s", exc)
+        return 0.0, 0.0, []
+
+    payloads: List[Dict[str, Any]] = []
+    pnls: List[float] = []
+    wins = 0
+
+    for point in results:
+        payload = getattr(point, "payload", {}) or {}
+        payloads.append(payload)
+        pnl = payload.get("pnl")
+        if isinstance(pnl, (int, float)):
+            pnls.append(float(pnl))
+        outcome = payload.get("outcome")
+        if bool(outcome):
+            wins += 1
+
+    avg_pnl = sum(pnls) / len(pnls) if pnls else 0.0
+    win_rate = wins / len(payloads) if payloads else 0.0
+
+    return avg_pnl, win_rate, payloads


### PR DESCRIPTION
## Summary
- add Qdrant-backed `score_embedding` helper for analog PnL scoring
- test vector backtester metrics and error handling with mocked Qdrant client

## Testing
- `pytest tests/test_vector_backtester.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4fd8eff808328960e8eabf3117e01