### PR TITLE
feat: add dynamic enrichment processors

### DIFF
--- a/config/enrichment_processors.yaml
+++ b/config/enrichment_processors.yaml
@@ -1,0 +1,9 @@
+# Ordered list of enrichment processors with per-processor settings
+processors:
+  - module: services.enrichment.modules.harmonic_processor
+    enabled: true
+    settings:
+      upload: false
+  - module: services.enrichment.modules.context_analyzer
+    enabled: false
+    settings: {}


### PR DESCRIPTION
## Summary
- add configurable enrichment processor list via config/enrichment_processors.yaml
- execute configured processors in pulse_kernel and aggregate their outputs

## Testing
- `python -m py_compile pulse_kernel.py`
- `pytest` *(fails: 47 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68c4fdfd41f08328909f95ca51455bb4