### PR TITLE
Add displacement and structure-shift metrics

### DIFF
--- a/tests/enrichment/test_dss.py
+++ b/tests/enrichment/test_dss.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from utils.enrichment.dss import compute_dss
+
+
+def test_dss_outputs_are_deterministic():
+    df = pd.DataFrame(
+        {
+            "open": [1, 2, 3, 4, 5],
+            "high": [1.1, 2.1, 3.1, 4.1, 5.1],
+            "low": [0.9, 1.9, 2.9, 3.9, 4.9],
+            "close": [1, 2, 3, 2, 1],
+        }
+    )
+    metrics, vec = compute_dss(df)
+    assert metrics["mean_displacement"] == 0.0
+    assert metrics["net_shift"] == 0.0
+    expected = np.array([[0, 0], [1, 1], [1, 1], [-1, -1], [-1, -1]], dtype=float)
+    assert np.array_equal(vec, expected)
+
+    # Second call should produce identical results
+    metrics2, vec2 = compute_dss(df)
+    assert metrics == metrics2
+    assert np.array_equal(vec, vec2)
+
+
+def test_dss_empty_dataframe():
+    df = pd.DataFrame(columns=["open", "high", "low", "close"])
+    metrics, vec = compute_dss(df)
+    assert metrics == {}
+    assert vec.size == 0

--- a/utils/enrichment/__init__.py
+++ b/utils/enrichment/__init__.py
@@ -1,7 +1,22 @@
-import pandas as pd
-import numpy as np
+"""Enrichment utilities and processors.
 
-TIMEFRAME_RULES = {
+This package exposes helper functions for enriching tick/bar data and
+collecting higher level analytics.  It also registers lightweight analytic
+processors such as the displacement/structure-shift (DSS) module.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+from . import dss  # noqa: F401 - re-export for convenience
+
+# ---------------------------------------------------------------------------
+# Basic enrichment helpers (migrated from legacy ``utils.enrichment`` module)
+# ---------------------------------------------------------------------------
+TIMEFRAME_RULES: Dict[str, str] = {
     "M1": "1T",
     "M5": "5T",
     "M15": "15T",
@@ -15,38 +30,30 @@ TIMEFRAME_RULES = {
 
 
 def aggregate_ticks_to_bars(ticks: pd.DataFrame, timeframe: str = "M1") -> pd.DataFrame:
-    """Aggregate tick data into OHLC bars using pandas resample.
+    """Aggregate tick data into OHLC bars using pandas ``resample``.
 
     Parameters
     ----------
-    ticks : pd.DataFrame
-        DataFrame containing tick data. It must have either a ``timestamp``
-        column or a datetime index along with a ``bid`` price column. If an
-        ``ask`` column is present it will be used to compute the mid price.
-    timeframe : str, default "M1"
-        Target timeframe in MT5 format (e.g. ``M1``, ``M5``). A valid pandas
-        resample string can also be provided.
-
-    Returns
-    -------
-    pd.DataFrame
-        Resampled bar data with ``open``, ``high``, ``low`` and ``close``
-        columns. ``volume`` will be summed if present in the input ``ticks``.
+    ticks:
+        Input tick data.  Must have either a ``timestamp`` column or a
+        datetime index and contain ``bid`` prices.  ``ask`` prices are used to
+        compute the mid price when present.
+    timeframe:
+        Target timeframe in MT5 notation (e.g. ``M1``, ``H1``) or any valid
+        pandas offset alias.
     """
-
     if ticks is None or ticks.empty:
         return pd.DataFrame()
 
     df = ticks.copy()
 
-    # Ensure datetime index
     if "timestamp" in df.columns:
         df["timestamp"] = pd.to_datetime(df["timestamp"])
         df.set_index("timestamp", inplace=True)
 
     rule = TIMEFRAME_RULES.get(timeframe.upper(), timeframe)
 
-    agg: dict[str, str | list[str]] = {"bid": ["first", "max", "min", "last"]}
+    agg: Dict[str, str | list[str]] = {"bid": ["first", "max", "min", "last"]}
     if "volume" in df.columns:
         agg["volume"] = "sum"
 
@@ -54,19 +61,17 @@ def aggregate_ticks_to_bars(ticks: pd.DataFrame, timeframe: str = "M1") -> pd.Da
     resampled.columns = ["open", "high", "low", "close"] + (
         ["volume"] if "volume" in df.columns else []
     )
-
     resampled.dropna(subset=["open"], inplace=True)
-
     return resampled
 
 
 def enrich_ticks(df: pd.DataFrame) -> pd.DataFrame:
     """Enrich tick or bar data with common metrics.
 
-    The function expects ``bid`` and ``ask`` columns where available. When
-    present, it derives ``mid_price`` and ``spread`` metrics. Simple
-    technical indicators like rolling averages and returns are also
-    calculated on the mid price.
+    When ``bid`` and ``ask`` columns are present, mid price and spread
+    statistics are derived.  Simple rolling averages and returns are computed
+    on the mid price to give downstream modules immediate contextual
+    information.
     """
     if df is None or df.empty:
         return df
@@ -88,3 +93,6 @@ def enrich_ticks(df: pd.DataFrame) -> pd.DataFrame:
         df["ma_20"] = df["mid_price"].rolling(20).mean()
 
     return df
+
+
+__all__ = ["aggregate_ticks_to_bars", "enrich_ticks", "dss"]

--- a/utils/enrichment/dss.py
+++ b/utils/enrichment/dss.py
@@ -1,0 +1,47 @@
+"""Displacement/Structure-Shift (DSS) metrics."""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+def compute_dss(df: pd.DataFrame) -> Tuple[Dict[str, float], np.ndarray]:
+    """Derive displacement and structure-shift metrics.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing at least a ``close`` column. The index or
+        ``timestamp`` column is not used, allowing callers to operate on raw
+        sequences.  The function is deterministic and stateless so repeated
+        calls on the same input return identical results.
+
+    Returns
+    -------
+    Tuple[Dict[str, float], np.ndarray]
+        A tuple ``(metrics, vector)`` where ``metrics`` summarises mean
+        displacement and net structure shift.  ``vector`` is a ``(N, 2)`` array
+        with displacement and shift for each row of ``df``.
+    """
+    if df is None or df.empty or "close" not in df.columns:
+        return {}, np.empty((0, 2), dtype=float)
+
+    close = df["close"].astype(float).to_numpy()
+
+    # Displacement is simply the first discrete difference; prepend 0 so the
+    # output aligns with the input length.
+    displacement = np.diff(close, prepend=close[0])
+    shift = np.sign(displacement)
+
+    metrics = {
+        "mean_displacement": float(displacement.mean()),
+        "net_shift": float(shift.sum()),
+    }
+
+    vector = np.column_stack((displacement, shift)).astype(float)
+    return metrics, vector
+
+
+__all__ = ["compute_dss"]


### PR DESCRIPTION
## Summary
- add DSS processor to derive displacement and structure-shift metrics
- expose DSS via utils.enrichment package alongside existing enrichment helpers
- add unit tests verifying DSS output determinism

## Testing
- `pytest tests/enrichment/test_dss.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4fdfe57b883288b2bc949b7134d57