### PR TITLE
test: add replay inspector tests

### DIFF
--- a/replay_inspector.py
+++ b/replay_inspector.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import pandas as pd
+
+
+def score_embedding(embedding: Sequence[float]) -> dict:
+    """Placeholder embedding scoring function.
+
+    The real implementation computes various similarity metrics for an embedding
+    vector.  Tests patch this function to provide deterministic metrics.
+    """
+
+    return {"score": float(sum(embedding))}
+
+
+class ReplayInspector:
+    """Inspect enriched tick data stored in Parquet files.
+
+    The inspector loads one or more Parquet files containing enriched ticks and
+    provides helpers for filtering, aggregating and exporting summary data.
+    """
+
+    def __init__(self, paths: Iterable[Path | str]):
+        if isinstance(paths, (str, Path)):
+            paths = [paths]
+        self._df = pd.concat([pd.read_parquet(Path(p)) for p in paths], ignore_index=True)
+
+    def filter(self, *, symbol: str | None = None, min_conf: float | None = None) -> pd.DataFrame:
+        """Return a filtered copy of the loaded dataframe."""
+
+        df = self._df
+        if symbol is not None:
+            df = df[df["symbol"] == symbol]
+        if min_conf is not None:
+            df = df[df["confidence"] >= min_conf]
+        return df.reset_index(drop=True)
+
+    def aggregate(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Aggregate metrics for a dataframe of ticks.
+
+        ``score_embedding`` is applied to the ``embedding`` column and the
+        resulting metrics are averaged per symbol along with the confidence.
+        """
+
+        metrics = df["embedding"].apply(score_embedding).apply(pd.Series)
+        df = df.drop(columns=["embedding"]).join(metrics)
+        numeric_cols = df.select_dtypes(include="number").columns
+        agg = df.groupby("symbol")[numeric_cols].mean().reset_index()
+        return agg
+
+    @staticmethod
+    def to_csv(df: pd.DataFrame, path: Path | str) -> None:
+        df.to_csv(path, index=False)
+
+    @staticmethod
+    def to_json(df: pd.DataFrame, path: Path | str) -> None:
+        df.to_json(path, orient="records", indent=2)

--- a/tests/test_replay_inspector.py
+++ b/tests/test_replay_inspector.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from replay_inspector import ReplayInspector, score_embedding
+
+
+def _create_parquet(path: Path) -> Path:
+    df = pd.DataFrame(
+        [
+            {"symbol": "BTC", "confidence": 0.9, "embedding": [0.1, 0.2]},
+            {"symbol": "BTC", "confidence": 0.8, "embedding": [0.3, 0.4]},
+            {"symbol": "ETH", "confidence": 0.7, "embedding": [0.5, 0.6]},
+        ]
+    )
+    out = path / "ticks.parquet"
+    df.to_parquet(out)
+    return out
+
+
+def test_filter_aggregate_and_export(tmp_path, monkeypatch):
+    parquet_path = _create_parquet(tmp_path)
+
+    def fake_score(emb):
+        return {"metric": round(sum(emb), 2)}
+
+    monkeypatch.setattr("replay_inspector.score_embedding", fake_score)
+
+    insp = ReplayInspector(parquet_path)
+    filtered = insp.filter(symbol="BTC", min_conf=0.8)
+    assert len(filtered) == 2
+
+    agg = insp.aggregate(filtered)
+    expected = pd.DataFrame(
+        [{"symbol": "BTC", "confidence": 0.85, "metric": 0.5}]
+    )
+    pd.testing.assert_frame_equal(agg, expected)
+
+    csv_path = tmp_path / "out.csv"
+    json_path = tmp_path / "out.json"
+    insp.to_csv(agg, csv_path)
+    insp.to_json(agg, json_path)
+
+    csv_df = pd.read_csv(csv_path)
+    pd.testing.assert_frame_equal(csv_df, expected)
+
+    with open(json_path) as fh:
+        data = json.load(fh)
+    assert data == [{"symbol": "BTC", "confidence": 0.85, "metric": 0.5}]


### PR DESCRIPTION
## Summary
- implement minimal `ReplayInspector` for inspecting enriched tick data
- add tests validating filtering, aggregation, and CSV/JSON exports

## Testing
- `pytest tests/test_replay_inspector.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4fd9007c08328881f7e7eeb05b828