### PR TITLE
Add UMAP and scikit-learn for dashboard analytics

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -20,6 +20,7 @@ streamlit run dashboard/Home.py
    ```bash
    pip install -r requirements/dashboard.txt  # or dashboard/requirements.txt
    ```
+   This pulls in core analytics libraries like `scikit-learn` and `umap-learn` needed for local development.
 2. **Environment** – ensure Redis and the Django API are reachable; most pages expect live data. Set `HEALTH_AGGREGATOR_URL` to the base URL of your health aggregator service.
 
 ## Customization

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -127,6 +127,7 @@ rich==13.7.0
 rpds-py==0.25.1
 schedule==1.2.2
 scikit-learn==1.7.0
+umap-learn==0.5.9.post2
 scipy==1.11.4
 seaborn==0.13.2
 self==2020.12.3

--- a/requirements/dashboard.txt
+++ b/requirements/dashboard.txt
@@ -10,3 +10,5 @@ pyyaml==6.0.1
 requests==2.32.3
 websocket-client==1.8.0
 ta==0.11.0
+scikit-learn==1.7.0
+umap-learn==0.5.9.post2


### PR DESCRIPTION
## Summary
- Include `umap-learn` and `scikit-learn` in dashboard-specific requirement files
- Document local install steps and note analytic dependencies in dashboard README

## Testing
- `pytest` *(fails: ModuleNotFoundError and missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_b_68c4fd87547083288aa813835af421e2