### PR TITLE
Add umap-learn and scikit-learn to dashboard requirements

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -20,6 +20,8 @@ streamlit run dashboard/Home.py
    ```bash
    pip install -r requirements/dashboard.txt  # or dashboard/requirements.txt
    ```
+   This installs the necessary Python packages, including `scikit-learn` and
+   `umap-learn`, which power machine-learning features in the dashboard.
 2. **Environment** – ensure Redis and the Django API are reachable; most pages expect live data. Set `HEALTH_AGGREGATOR_URL` to the base URL of your health aggregator service.
 
 ## Customization

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -126,7 +126,8 @@ requests==2.32.4
 rich==13.7.0
 rpds-py==0.25.1
 schedule==1.2.2
-scikit-learn==1.7.0
+scikit-learn==1.7.2
+umap-learn==0.5.6
 scipy==1.11.4
 seaborn==0.13.2
 self==2020.12.3

--- a/requirements/dashboard.txt
+++ b/requirements/dashboard.txt
@@ -10,3 +10,5 @@ pyyaml==6.0.1
 requests==2.32.3
 websocket-client==1.8.0
 ta==0.11.0
+scikit-learn==1.7.2
+umap-learn==0.5.6


### PR DESCRIPTION
## Summary
- add `scikit-learn` and `umap-learn` to dashboard requirements
- document ML package installation in dashboard README

## Testing
- `pre-commit run --files dashboard/requirements.txt requirements/dashboard.txt dashboard/README.md`
- `pytest` *(fails: populate() isn't reentrant and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c4fd8337448328963f8f330f614764