### PR TITLE
Add Qdrant-based vector backtester with scoring

### DIFF
--- a/tests/test_vector_backtester.py
+++ b/tests/test_vector_backtester.py
@@ -1,0 +1,52 @@
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils import vector_backtester
+
+
+def _make_result(payload):
+    return types.SimpleNamespace(payload=payload)
+
+
+def test_score_embedding_success():
+    embedding = [0.1, 0.2]
+    mock_results = [
+        _make_result({"pnl": 1.0}),
+        _make_result({"pnl": -1.0}),
+        _make_result({"pnl": 2.0}),
+    ]
+    mock_client = MagicMock()
+    mock_client.search.return_value = mock_results
+
+    with patch.object(vector_backtester, "_client", mock_client):
+        avg_pnl, win_rate, payloads = vector_backtester.score_embedding(embedding)
+
+    mock_client.search.assert_called_once_with(
+        collection_name=vector_backtester.QDRANT_COLLECTION,
+        query_vector=embedding,
+        limit=10,
+    )
+    assert avg_pnl == pytest.approx((1.0 - 1.0 + 2.0) / 3)
+    assert win_rate == pytest.approx(2 / 3)
+    assert payloads == [r.payload for r in mock_results]
+
+
+def test_score_embedding_handles_errors():
+    embedding = [0.5, 0.4]
+    mock_client = MagicMock()
+    mock_client.search.side_effect = Exception("boom")
+
+    with patch.object(vector_backtester, "_client", mock_client):
+        avg_pnl, win_rate, payloads = vector_backtester.score_embedding(embedding)
+
+    assert avg_pnl == 0.0
+    assert win_rate == 0.0
+    assert payloads == []
+
+    with patch.object(vector_backtester, "_client", None):
+        avg_pnl, win_rate, payloads = vector_backtester.score_embedding(embedding)
+        assert avg_pnl == 0.0
+        assert win_rate == 0.0
+        assert payloads == []

--- a/utils/vector_backtester.py
+++ b/utils/vector_backtester.py
@@ -1,0 +1,67 @@
+"""Vector backtesting utilities using Qdrant."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import List, Tuple, Dict, Any
+
+try:
+    from qdrant_client import QdrantClient
+except Exception:  # pragma: no cover - library may be missing in tests
+    QdrantClient = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+QDRANT_URL = os.getenv("QDRANT_URL", "")
+QDRANT_API_KEY = os.getenv("QDRANT_API_KEY", "")
+QDRANT_COLLECTION = os.getenv("QDRANT_COLLECTION", "enriched")
+
+_client: QdrantClient | None = None
+
+if QdrantClient and QDRANT_URL:
+    try:
+        _client = QdrantClient(url=QDRANT_URL, api_key=QDRANT_API_KEY)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to initialize Qdrant client: %s", exc)
+        _client = None
+else:
+    if not QdrantClient:
+        logger.warning("QdrantClient library not available; vector backtesting disabled")
+    else:
+        logger.warning("QDRANT_URL not set; vector backtesting disabled")
+
+
+def score_embedding(embedding: List[float]) -> Tuple[float, float, List[Dict[str, Any]]]:
+    """Score an embedding against historical analogs.
+
+    Returns a tuple of ``(average_pnl, win_rate, payloads)``. If the Qdrant
+    service is unreachable or no analogs are found, zeros are returned along
+    with an empty payload list.
+    """
+
+    if _client is None:
+        logger.warning("Qdrant client unavailable; returning default scores")
+        return 0.0, 0.0, []
+
+    try:
+        results = _client.search(
+            collection_name=QDRANT_COLLECTION,
+            query_vector=embedding,
+            limit=10,
+        )
+    except Exception as exc:  # pragma: no cover - network/HTTP errors
+        logger.warning("Qdrant search failed: %s", exc)
+        return 0.0, 0.0, []
+
+    payloads = [getattr(res, "payload", {}) for res in results]
+    pnls = [p.get("pnl") for p in payloads if p.get("pnl") is not None]
+
+    if not pnls:
+        return 0.0, 0.0, payloads
+
+    avg_pnl = sum(pnls) / len(pnls)
+    wins = sum(1 for pnl in pnls if pnl > 0)
+    win_rate = wins / len(pnls)
+
+    return avg_pnl, win_rate, payloads


### PR DESCRIPTION
## Summary
- provide vector_backtester utility that connects to Qdrant and scores embeddings
- test scoring logic and error handling via mocked Qdrant client

## Testing
- `pytest tests/test_vector_backtester.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c4fd37f7f083288ef28cb1e9dffebb