### PR TITLE
Add vectorized enrichment configuration with nested flags

### DIFF
--- a/config/enrichment_vectorized.yaml
+++ b/config/enrichment_vectorized.yaml
@@ -1,16 +1,9 @@
-# Vectorized enrichment configuration with per-module toggles.
-vectorized:
-  smc: true
-  poi: true
-  divergence: true
-  rsi_fusion: true
+# Vectorized enrichment configuration with nested flags.
+smc:
+  liquidity_grabs: true
+  order_blocks: true
+poi:
+  imbalances: true
+rsi:
+  overbought_threshold: 70
 
-advanced:
-  harmonic:
-    enabled: false
-
-vector_db:
-  collection: enrichment_vectors
-
-embedding:
-  model: text-embedding-3-small

--- a/docs/enrichment_engine.md
+++ b/docs/enrichment_engine.md
@@ -56,6 +56,19 @@ configuration is provided at
 defines the harmonic tolerance and pivot window along with the target
 embedding model and collection name.
 
+For vectorized runs, [`config/enrichment_vectorized.yaml`](../config/enrichment_vectorized.yaml)
+defines nested flags for individual features:
+
+```yaml
+smc:
+  liquidity_grabs: true
+  order_blocks: true
+poi:
+  imbalances: true
+rsi:
+  overbought_threshold: 70
+```
+
 ### Pydantic configuration model
 
 The groups are represented by the Pydantic


### PR DESCRIPTION
## Summary
- Replace vectorized enrichment config with nested feature flags for SMC, POI, and RSI
- Document vectorized configuration format in enrichment engine docs

## Testing
- `pre-commit run --files config/enrichment_vectorized.yaml docs/enrichment_engine.md`
- `pytest -q` *(fails: RuntimeError: POSTGRES_PASSWORD environment variable is required, ModuleNotFoundError: No module named 'pyarrow', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68c54485bc2883289f2f3d6d3296889b