### PR TITLE
Add enrichment configuration endpoint

### DIFF
--- a/backend/django/app/nexus/pulse/urls.py
+++ b/backend/django/app/nexus/pulse/urls.py
@@ -6,6 +6,7 @@ from .views import (
     PulseGateHits,
     BarsEnriched,
     EnrichmentConfig,
+    ConfigureEnrichment,
     YFBars,
     TradeQualityDist,
     DiscordHealth,
@@ -18,6 +19,7 @@ urlpatterns = [
     path('feed/pulse-gate-hits', PulseGateHits.as_view(), name='pulse-gate-hits'),
     path('feed/bars-enriched', BarsEnriched.as_view(), name='bars-enriched'),
     path('feed/enrichment-config', EnrichmentConfig.as_view(), name='enrichment-config'),
+    path('enrichment/configure', ConfigureEnrichment.as_view(), name='configure-enrichment'),
     path('feed/yf-bars', YFBars.as_view(), name='yf-bars'),
     path('feed/trade-quality', TradeQualityDist.as_view(), name='trade-quality'),
     # Health


### PR DESCRIPTION
## Summary
- allow runtime updates to enrichment config via `ConfigureEnrichment` API view
- register `/enrichment/configure` route
- keep latest enrichment configuration in memory for pipeline usage

## Testing
- `pytest tests/test_enrichment_config.py -q`
- `python -m py_compile backend/django/app/nexus/pulse/views.py backend/django/app/nexus/pulse/urls.py`


------
https://chatgpt.com/codex/tasks/task_b_68c54491b3548328bab50b010889c99f