### PR TITLE
feat: extend enrichment config toggles

### DIFF
--- a/config/enrichment_vectorized.yaml
+++ b/config/enrichment_vectorized.yaml
@@ -1,9 +1,16 @@
 # Vectorized enrichment configuration with per-module toggles.
 vectorized:
-  smc: true
-  poi: true
+  toggles:
+    smc: true
+    poi: true
+    indicators:
+      liquidity_zones: true
+      order_blocks: true
   divergence: true
   rsi_fusion: true
+  rsi_thresholds:
+    lower: 30
+    upper: 70
 
 advanced:
   harmonic:

--- a/services/enrichment/main.py
+++ b/services/enrichment/main.py
@@ -12,15 +12,16 @@ def main(
     dataframe: Any,
     metadata: Dict[str, Any],
     configs: Optional[Dict[str, Dict[str, Any]]] = None,
-    config_path: str = "config/enrichment_default.yaml",
+    config_path: str = "config/enrichment_vectorized.yaml",
 ) -> Dict[str, Any]:
     """Execute the enrichment pipeline and return its final state.
 
     Configuration is loaded from ``config_path`` and validated using
-    :class:`~utils.enrichment_config.EnrichmentConfig`.  To enable harmonic
-    pattern enrichment with vector database persistence, pass
-    ``config/enrichment_harmonic.yaml``.  Any configs passed explicitly will
-    override the defaults.
+    :class:`~utils.enrichment_config.EnrichmentConfig`.  The default
+    configuration ``config/enrichment_vectorized.yaml`` enables the
+    vectorized enrichment modules. To enable harmonic pattern enrichment
+    with vector database persistence, pass ``config/enrichment_harmonic.yaml``.
+    Any configs passed explicitly will override the defaults.
     """
 
     base_cfg = load_enrichment_config(config_path).to_module_configs()

--- a/utils/enrichment_config.py
+++ b/utils/enrichment_config.py
@@ -124,13 +124,36 @@ class HarmonicConfig(BaseModel):
     upload: bool = False
 
 
-class VectorizedConfig(BaseModel):
-    """Toggles for vectorized enrichment modules."""
+class IndicatorToggles(BaseModel):
+    """Toggle configuration for SMC/POI and specific indicators."""
 
     smc: bool = True
     poi: bool = True
+    indicators: Mapping[str, bool] = Field(
+        default_factory=dict,
+        description="Mapping of indicator name to enabled flag",
+    )
+
+    def enabled_indicators(self) -> List[str]:
+        """Return a list of indicator names that are enabled."""
+
+        return [name for name, flag in self.indicators.items() if flag]
+
+
+class RSIThresholds(BaseModel):
+    """Upper and lower thresholds for RSI-based indicators."""
+
+    lower: float = Field(30, description="Oversold threshold")
+    upper: float = Field(70, description="Overbought threshold")
+
+
+class VectorizedConfig(BaseModel):
+    """Toggles for vectorized enrichment modules."""
+
+    toggles: IndicatorToggles = Field(default_factory=IndicatorToggles)
     divergence: bool = True
     rsi_fusion: bool = True
+    rsi_thresholds: RSIThresholds = Field(default_factory=RSIThresholds)
 
 
 class VectorDBConfig(BaseModel):
@@ -185,11 +208,6 @@ class EnrichmentConfig(BaseModel):
             "liquidity_engine": {"enabled": self.advanced.liquidity_engine},
             "context_analyzer": {"enabled": self.advanced.context_analyzer},
             "fvg_locator": {"enabled": self.advanced.fvg_locator},
-            "harmonic_processor": {
-                "enabled": self.advanced.harmonic.enabled,
-                "collection": self.advanced.harmonic.collection,
-                "upload": self.advanced.harmonic.upload,
-            },
             "predictive_scorer": {"enabled": self.advanced.predictive_scorer},
             "fractal_detector": {
                 "enabled": self.advanced.fractal_detector,
@@ -209,14 +227,29 @@ class EnrichmentConfig(BaseModel):
             },
             "harmonic_processor": {
                 "enabled": self.advanced.harmonic.enabled,
+                "collection": self.advanced.harmonic.collection,
+                "upload": self.advanced.harmonic.upload,
                 "tolerance": self.advanced.harmonic.tolerance,
                 "window": self.advanced.harmonic.window,
             },
-            "smc": {"enabled": self.vectorized.smc},
-            "poi": {"enabled": self.vectorized.poi},
+            "smc": {"enabled": self.vectorized.toggles.smc},
+            "poi": {"enabled": self.vectorized.toggles.poi},
             "divergence": {"enabled": self.vectorized.divergence},
-            "rsi_fusion": {"enabled": self.vectorized.rsi_fusion},
+            "rsi_fusion": {
+                "enabled": self.vectorized.rsi_fusion,
+                "thresholds": {
+                    "lower": self.vectorized.rsi_thresholds.lower,
+                    "upper": self.vectorized.rsi_thresholds.upper,
+                },
+            },
         }
+
+    def apply_indicator_toggles(self) -> None:
+        """Apply indicator enable/disable settings to the global registry."""
+
+        from indicators.registry import set_enabled
+
+        set_enabled(self.vectorized.toggles.enabled_indicators())
 
 
 def load_enrichment_config(
@@ -264,6 +297,8 @@ __all__ = [
     "AlligatorConfig",
     "ElliottConfig",
     "HarmonicConfig",
+    "IndicatorToggles",
+    "RSIThresholds",
     "VectorizedConfig",
     "VectorDBConfig",
     "EmbeddingConfig",


### PR DESCRIPTION
## Summary
- add IndicatorToggles and RSIThresholds models for vectorized enrichment
- merge harmonic processor options into a single configuration block
- default to `enrichment_vectorized.yaml` in enrichment service entrypoint

## Testing
- `pytest tests/test_enrichment_config.py tests/test_indicator_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68c544878a588328bcc9a82f1350f489