### PR TITLE
feat: add SMC analyzer feature toggles

### DIFF
--- a/tests/test_harmonic_unified_analysis.py
+++ b/tests/test_harmonic_unified_analysis.py
@@ -16,13 +16,7 @@ def _import_analysis_engines():
     cps = ModuleType("core.predictive_scorer")
     cps.PredictiveScorer = DummyPredictiveScorer
     sys.modules["core.predictive_scorer"] = cps
-    sys.modules.pop("schemas", None)
-    sys.modules.pop("schemas.predictive_schemas", None)
-    sys.modules.pop("schemas.behavioral", None)
-    ps = importlib.import_module("schemas.predictive_schemas")
-    sys.modules["schemas.predictive_schemas"] = ps
-    if "utils.analysis_engines" in sys.modules:
-        importlib.reload(sys.modules["utils.analysis_engines"])
+    sys.modules.pop("utils.analysis_engines", None)
     return importlib.import_module("utils.analysis_engines")
 
 
@@ -36,8 +30,8 @@ def test_build_unified_analysis_includes_harmonic():
         "timestamp": 0,
         "harmonic": {
             "harmonic_patterns": [{"pattern": "bat"}],
-            "prz": [{"low": 1.0, "high": 1.2}],
-            "confidence": [0.9],
+            "prz": {"low": 1.0, "high": 1.2},
+            "confidence": 0.9,
         },
     }
     payload = ae.build_unified_analysis(tick, cfg)

--- a/tests/test_smc_analyzer.py
+++ b/tests/test_smc_analyzer.py
@@ -48,3 +48,11 @@ def test_analyze():
     assert expected_keys.issubset(results.keys())
     assert results["liquidity_zones"] == expected_lz
     assert results["order_blocks"] == expected_ob
+
+
+def test_feature_toggle_disables_analysis():
+    df = _sample_df()
+    analyzer = SMCAnalyzer(features={"liquidity_sweeps": False})
+    assert "liquidity_sweeps" not in analyzer._features
+    results = analyzer.analyze(df)
+    assert "liquidity_sweeps" not in results

--- a/utils/analysis_engines.py
+++ b/utils/analysis_engines.py
@@ -83,7 +83,7 @@ def build_unified_analysis(
             import pandas as pd
             from core.smc_analyzer import SMCAnalyzer
 
-            smc_engine = SMCAnalyzer()
+            smc_engine = SMCAnalyzer(features=cfg.structure.smc_features)
             smc_res = smc_engine.analyze(pd.DataFrame(bars))
             smc = SMCAnalysis(
                 market_structure=smc_res.get("market_structure"),

--- a/utils/enrichment_config.py
+++ b/utils/enrichment_config.py
@@ -79,8 +79,11 @@ class TechnicalConfig(BaseModel):
 
 class StructureConfig(BaseModel):
     """Structure analysis toggles (SMC / Wyckoff)."""
-
     smc: bool = Field(True, description="Enable Smart Money Concepts analysis")
+    smc_features: Dict[str, bool] = Field(
+        default_factory=dict,
+        description="Per-feature toggles for SMC analysis",
+    )
     wyckoff: bool = Field(True, description="Enable Wyckoff phase analysis")
 
 


### PR DESCRIPTION
## Summary
- allow SMCAnalyzer to accept per-feature toggles and skip disabled indicators
- pass SMC feature toggles from EnrichmentConfig through build_unified_analysis
- expose `smc_features` mapping on EnrichmentConfig for per-feature control

## Testing
- `pytest tests/test_smc_analyzer.py tests/test_smc.py tests/test_enrichment_config.py tests/test_harmonic_unified_analysis.py`

------
https://chatgpt.com/codex/tasks/task_b_68c5448defa883289e828ea65aa30799