### PR TITLE
feat: configurable RSI thresholds

### DIFF
--- a/backend/django/app/components/analysis_panel.py
+++ b/backend/django/app/components/analysis_panel.py
@@ -6,9 +6,20 @@
 
 import streamlit as st
 import pandas as pd
+from utils.enrichment_config import EnrichmentConfig
 
 class AnalysisPanel:
-    def __init__(self):
+    def __init__(self, config: EnrichmentConfig | None = None):
+        self.overbought_threshold = (
+            config.technical.overbought_threshold
+            if config
+            else 70
+        )
+        self.oversold_threshold = (
+            config.technical.oversold_threshold
+            if config
+            else 30
+        )
         self.panel_config = {
             'smc': {
                 'title': '🏛️ Smart Money Concepts',
@@ -228,7 +239,11 @@ class AnalysisPanel:
             st.subheader("Momentum")
             if 'rsi' in results and len(results['rsi']) > 0:
                 rsi = results['rsi'].iloc[-1] if hasattr(results['rsi'], 'iloc') else results['rsi'][-1]
-                rsi_status = "🔴 Overbought" if rsi > 70 else "🟢 Oversold" if rsi < 30 else "Neutral"
+                rsi_status = (
+                    "🔴 Overbought"
+                    if rsi > self.overbought_threshold
+                    else "🟢 Oversold" if rsi < self.oversold_threshold else "Neutral"
+                )
                 st.metric("RSI", f"{rsi:.1f}", rsi_status)
             
             if 'macd_diff' in results and len(results['macd_diff']) > 0:

--- a/backend/django/app/components/technical_analysis.py
+++ b/backend/django/app/components/technical_analysis.py
@@ -10,11 +10,18 @@ try:
     import ta  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     ta = None
+from utils.enrichment_config import EnrichmentConfig
 
 class TechnicalAnalysis:
-    def __init__(self):
+    def __init__(self, config: EnrichmentConfig | None = None):
         self.indicators = {}
         self.calculate_indicators = self.calculate_all
+        if config:
+            self.overbought_threshold = config.technical.overbought_threshold
+            self.oversold_threshold = config.technical.oversold_threshold
+        else:
+            self.overbought_threshold = 70
+            self.oversold_threshold = 30
 
     def calculate_all(self, df):
         """Calculate all technical indicators"""
@@ -212,8 +219,8 @@ class TechnicalAnalysis:
             if len(rsi) > 0:
                 confluence['momentum'][tf] = {
                     'rsi': rsi.iloc[-1],
-                    'overbought': rsi.iloc[-1] > 70,
-                    'oversold': rsi.iloc[-1] < 30
+                    'overbought': rsi.iloc[-1] > self.overbought_threshold,
+                    'oversold': rsi.iloc[-1] < self.oversold_threshold
                 }
         
         # Cluster key levels across timeframes

--- a/components/analysis_panel.py
+++ b/components/analysis_panel.py
@@ -6,9 +6,20 @@
 
 import streamlit as st
 import pandas as pd
+from utils.enrichment_config import EnrichmentConfig
 
 class AnalysisPanel:
-    def __init__(self):
+    def __init__(self, config: EnrichmentConfig | None = None):
+        self.overbought_threshold = (
+            config.technical.overbought_threshold
+            if config
+            else 70
+        )
+        self.oversold_threshold = (
+            config.technical.oversold_threshold
+            if config
+            else 30
+        )
         self.panel_config = {
             'smc': {
                 'title': '🏛️ Smart Money Concepts',
@@ -228,7 +239,11 @@ class AnalysisPanel:
             st.subheader("Momentum")
             if 'rsi' in results and len(results['rsi']) > 0:
                 rsi = results['rsi'].iloc[-1] if hasattr(results['rsi'], 'iloc') else results['rsi'][-1]
-                rsi_status = "🔴 Overbought" if rsi > 70 else "🟢 Oversold" if rsi < 30 else "Neutral"
+                rsi_status = (
+                    "🔴 Overbought"
+                    if rsi > self.overbought_threshold
+                    else "🟢 Oversold" if rsi < self.oversold_threshold else "Neutral"
+                )
                 st.metric("RSI", f"{rsi:.1f}", rsi_status)
             
             if 'macd_diff' in results and len(results['macd_diff']) > 0:

--- a/components/technical_analysis.py
+++ b/components/technical_analysis.py
@@ -10,11 +10,18 @@ try:
     import ta  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     ta = None
+from utils.enrichment_config import EnrichmentConfig
 
 class TechnicalAnalysis:
-    def __init__(self):
+    def __init__(self, config: EnrichmentConfig | None = None):
         self.indicators = {}
         self.calculate_indicators = self.calculate_all
+        if config:
+            self.overbought_threshold = config.technical.overbought_threshold
+            self.oversold_threshold = config.technical.oversold_threshold
+        else:
+            self.overbought_threshold = 70
+            self.oversold_threshold = 30
 
     def calculate_all(self, df):
         """Calculate all technical indicators"""
@@ -212,8 +219,8 @@ class TechnicalAnalysis:
             if len(rsi) > 0:
                 confluence['momentum'][tf] = {
                     'rsi': rsi.iloc[-1],
-                    'overbought': rsi.iloc[-1] > 70,
-                    'oversold': rsi.iloc[-1] < 30
+                    'overbought': rsi.iloc[-1] > self.overbought_threshold,
+                    'oversold': rsi.iloc[-1] < self.oversold_threshold
                 }
         
         # Cluster key levels across timeframes

--- a/config/enrichment_default.yaml
+++ b/config/enrichment_default.yaml
@@ -5,6 +5,8 @@ core:
   structure_validator: true
 
 technical:
+  overbought_threshold: 70
+  oversold_threshold: 30
   groups:
     momentum:
       enabled: true

--- a/tests/test_enrichment_config.py
+++ b/tests/test_enrichment_config.py
@@ -30,6 +30,12 @@ def test_default_groups_present():
     assert "volatility" in cfg.technical.groups
 
 
+def test_rsi_threshold_defaults():
+    cfg = EnrichmentConfig()
+    assert cfg.technical.overbought_threshold == 70
+    assert cfg.technical.oversold_threshold == 30
+
+
 def test_build_unified_analysis_skips_technical(monkeypatch):
     ae = _import_analysis_engines()
     cfg = EnrichmentConfig()

--- a/utils/analysis_panel.py
+++ b/utils/analysis_panel.py
@@ -6,9 +6,20 @@
 
 import streamlit as st
 import pandas as pd
+from utils.enrichment_config import EnrichmentConfig
 
 class AnalysisPanel:
-    def __init__(self):
+    def __init__(self, config: EnrichmentConfig | None = None):
+        self.overbought_threshold = (
+            config.technical.overbought_threshold
+            if config
+            else 70
+        )
+        self.oversold_threshold = (
+            config.technical.oversold_threshold
+            if config
+            else 30
+        )
         self.panel_config = {
             'smc': {
                 'title': '🏛️ Smart Money Concepts',
@@ -228,7 +239,11 @@ class AnalysisPanel:
             st.subheader("Momentum")
             if 'rsi' in results and len(results['rsi']) > 0:
                 rsi = results['rsi'].iloc[-1] if hasattr(results['rsi'], 'iloc') else results['rsi'][-1]
-                rsi_status = "🔴 Overbought" if rsi > 70 else "🟢 Oversold" if rsi < 30 else "Neutral"
+                rsi_status = (
+                    "🔴 Overbought"
+                    if rsi > self.overbought_threshold
+                    else "🟢 Oversold" if rsi < self.oversold_threshold else "Neutral"
+                )
                 st.metric("RSI", f"{rsi:.1f}", rsi_status)
             
             if 'macd_diff' in results and len(results['macd_diff']) > 0:

--- a/utils/enrichment_config.py
+++ b/utils/enrichment_config.py
@@ -53,7 +53,12 @@ def _default_technical_groups() -> Dict[str, TechnicalSubGroup]:
 
 class TechnicalConfig(BaseModel):
     """Configuration for technical indicator groups."""
-
+    overbought_threshold: float = Field(
+        70, description="RSI value considered overbought"
+    )
+    oversold_threshold: float = Field(
+        30, description="RSI value considered oversold"
+    )
     groups: Dict[str, TechnicalSubGroup] = Field(
         default_factory=_default_technical_groups
     )
@@ -181,7 +186,11 @@ class EnrichmentConfig(BaseModel):
 
         return {
             "structure_validator": {"enabled": self.core.structure_validator},
-            "technical_indicators": {"enabled": self.technical.enabled},
+            "technical_indicators": {
+                "enabled": self.technical.enabled,
+                "overbought_threshold": self.technical.overbought_threshold,
+                "oversold_threshold": self.technical.oversold_threshold,
+            },
             "liquidity_engine": {"enabled": self.advanced.liquidity_engine},
             "context_analyzer": {"enabled": self.advanced.context_analyzer},
             "fvg_locator": {"enabled": self.advanced.fvg_locator},

--- a/utils/technical_analysis.py
+++ b/utils/technical_analysis.py
@@ -7,11 +7,18 @@
 import pandas as pd
 import numpy as np
 import ta
+from utils.enrichment_config import EnrichmentConfig
 
 class TechnicalAnalysis:
-    def __init__(self):
+    def __init__(self, config: EnrichmentConfig | None = None):
         self.indicators = {}
         self.calculate_indicators = self.calculate_all
+        if config:
+            self.overbought_threshold = config.technical.overbought_threshold
+            self.oversold_threshold = config.technical.oversold_threshold
+        else:
+            self.overbought_threshold = 70
+            self.oversold_threshold = 30
 
     def calculate_all(self, df):
         """Calculate all technical indicators"""
@@ -207,8 +214,8 @@ class TechnicalAnalysis:
             if len(rsi) > 0:
                 confluence['momentum'][tf] = {
                     'rsi': rsi.iloc[-1],
-                    'overbought': rsi.iloc[-1] > 70,
-                    'oversold': rsi.iloc[-1] < 30
+                    'overbought': rsi.iloc[-1] > self.overbought_threshold,
+                    'oversold': rsi.iloc[-1] < self.oversold_threshold
                 }
         
         # Cluster key levels across timeframes


### PR DESCRIPTION
## Summary
- make RSI overbought/oversold levels configurable through EnrichmentConfig
- use configured thresholds in multi-timeframe analysis
- display RSI status using thresholds across analysis panels

## Testing
- `pytest` *(fails: populate() isn't reentrant, etc.)*
- `pytest tests/test_enrichment_config.py`


------
https://chatgpt.com/codex/tasks/task_b_68c5448f4b5c8328854a165a130e7906