### PR TITLE
Expose enrichment helpers at package level and update tests

### DIFF
--- a/tests/enrichment/test_dss.py
+++ b/tests/enrichment/test_dss.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from utils.enrichment.dss import compute_dss
+from utils.enrichment import compute_dss
 
 
 def test_dss_outputs_are_deterministic():

--- a/tests/enrichment/test_smc.py
+++ b/tests/enrichment/test_smc.py
@@ -1,4 +1,4 @@
-from utils.enrichment import smc_process
+from utils.enrichment import smc_process  # package-level export
 
 
 def test_smc_process_features_and_vector():

--- a/utils/enrichment/__init__.py
+++ b/utils/enrichment/__init__.py
@@ -104,7 +104,17 @@ def enrich_ticks(df: pd.DataFrame) -> pd.DataFrame:
 
     return df
 
-# Expose POI processor
+# Re-export selected processors and helpers for convenience
 from . import poi
+from .smc import process as smc_process
+from .dss import compute_dss
+from .rsi import RSIProcessor
 
-__all__ = ["aggregate_ticks_to_bars", "enrich_ticks", "poi"]
+__all__ = [
+    "aggregate_ticks_to_bars",
+    "enrich_ticks",
+    "poi",
+    "smc_process",
+    "compute_dss",
+    "RSIProcessor",
+]


### PR DESCRIPTION
## Summary
- Re-export `smc.process`, `dss.compute_dss`, and `RSIProcessor` via `utils.enrichment`
- Update `__all__` for the new exports
- Adjust enrichment tests to use the package API

## Testing
- `pytest tests/enrichment -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5465df14883289cc74a471b374afc