### PR TITLE
Add process wrappers for DSS and RSI enrichment

### DIFF
--- a/tests/enrichment/test_dss.py
+++ b/tests/enrichment/test_dss.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from utils.enrichment.dss import compute_dss
+from utils.enrichment.dss import compute_dss, process
 
 
 def test_dss_outputs_are_deterministic():
@@ -32,3 +32,22 @@ def test_dss_empty_dataframe():
     metrics, vec = compute_dss(df)
     assert metrics == {}
     assert vec.size == 0
+
+    result = process(df)
+    assert result["metrics"] == {}
+    assert result["vector"].size == 0
+
+
+def test_dss_process_wrapper():
+    df = pd.DataFrame(
+        {
+            "open": [1, 2, 3, 4, 5],
+            "high": [1.1, 2.1, 3.1, 4.1, 5.1],
+            "low": [0.9, 1.9, 2.9, 3.9, 4.9],
+            "close": [1, 2, 3, 2, 1],
+        }
+    )
+    result = process(df)
+    metrics, vec = compute_dss(df)
+    assert result["metrics"] == metrics
+    assert np.array_equal(result["vector"], vec)

--- a/tests/enrichment/test_rsi.py
+++ b/tests/enrichment/test_rsi.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from utils.enrichment import RSIProcessor
+from utils.enrichment.rsi import RSIProcessor, process
 
 
 def test_rsi_processor_matches_expected_values():
@@ -45,3 +45,16 @@ def test_rsi_processor_without_vector():
     enriched, vector = RSIProcessor().enrich(df)
     assert vector is None
     assert "rsi_14" in enriched.columns
+
+
+def test_rsi_process_wrapper():
+    df = pd.DataFrame({"close": np.linspace(1, 30, 30)})
+    result, vector = process(df, return_vector=True)
+    enriched = result["df"]
+    assert "rsi_14" in enriched.columns
+    assert isinstance(vector, np.ndarray)
+    assert np.allclose(vector, enriched["rsi_14"].to_numpy(), equal_nan=True)
+
+    result_no_vec, vector_none = process(df)
+    assert vector_none is None
+    assert "rsi_14" in result_no_vec["df"].columns

--- a/utils/enrichment/dss.py
+++ b/utils/enrichment/dss.py
@@ -44,4 +44,15 @@ def compute_dss(df: pd.DataFrame) -> Tuple[Dict[str, float], np.ndarray]:
     return metrics, vector
 
 
-__all__ = ["compute_dss"]
+def process(df: pd.DataFrame) -> Dict[str, np.ndarray | Dict[str, float]]:
+    """Return DSS metrics and vector in a single dictionary.
+
+    The helper simply wraps :func:`compute_dss` to provide a consistent
+    dictionary-based API with ``metrics`` and ``vector`` keys.
+    """
+
+    metrics, vec = compute_dss(df)
+    return {"metrics": metrics, "vector": vec}
+
+
+__all__ = ["compute_dss", "process"]

--- a/utils/enrichment/rsi.py
+++ b/utils/enrichment/rsi.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -70,4 +70,26 @@ class RSIProcessor:
         return enriched, vector
 
 
-__all__ = ["RSIProcessor"]
+def process(
+    df: pd.DataFrame,
+    period: int = 14,
+    return_vector: bool = False,
+) -> Tuple[Dict[str, pd.DataFrame], Optional[np.ndarray]]:
+    """Convenience wrapper returning a dictionary plus optional vector.
+
+    Parameters
+    ----------
+    df:
+        Input price DataFrame.
+    period:
+        RSI lookback period, forwarded to :class:`RSIProcessor`.
+    return_vector:
+        When ``True`` also return the raw RSI values as a vector.
+    """
+
+    processor = RSIProcessor(period=period)
+    enriched, vector = processor.enrich(df, return_vector=return_vector)
+    return {"df": enriched}, vector
+
+
+__all__ = ["RSIProcessor", "process"]


### PR DESCRIPTION
## Summary
- add `process` wrapper for DSS metrics returning metrics and vector in a dict
- add module-level `process` to RSI module for easy enrichment plus optional vector
- test DSS and RSI wrappers

## Testing
- `pytest tests/enrichment/test_dss.py tests/enrichment/test_rsi.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5465bbddc8328b754f0d0b5367f41