### PR TITLE
Measure enrichment processor runtime

### DIFF
--- a/pulse_kernel.py
+++ b/pulse_kernel.py
@@ -282,6 +282,7 @@ class PulseKernel:
     async def _calculate_confluence(self, data: Dict) -> Dict:
         """Run configured enrichment processors and aggregate their outputs."""
         aggregate: Dict[str, Any] = {}
+        start_time = time.perf_counter()
         for proc in self.enrichment_processors:
             module_path = proc.get("module")
             if not module_path:
@@ -317,6 +318,9 @@ class PulseKernel:
                     aggregate[key].update(value)
                 else:
                     aggregate[key] = value
+        duration = time.perf_counter() - start_time
+        if duration > 0.4:
+            logger.warning("Enrichment processors took %.3fs", duration)
         return aggregate
     
     async def _enforce_risk(self, confluence_result: Dict) -> Dict:

--- a/tests/enrichment/test_runtime.py
+++ b/tests/enrichment/test_runtime.py
@@ -1,0 +1,48 @@
+import asyncio
+import sys
+import time
+import types
+
+# Stub heavy dependencies before importing PulseKernel
+_sms = types.ModuleType("core.semantic_mapping_service")
+_sms.SemanticMappingService = object
+sys.modules.setdefault("core.semantic_mapping_service", _sms)
+
+_ct = types.ModuleType("core.confidence_tracer")
+_ct.ConfidenceTracer = object
+sys.modules.setdefault("core.confidence_tracer", _ct)
+
+_re = types.ModuleType("components.risk_enforcer")
+_re.RiskEnforcer = object
+sys.modules.setdefault("components.risk_enforcer", _re)
+sys.modules.setdefault("risk_enforcer", _re)
+
+from pulse_kernel import PulseKernel
+
+
+def _make_proc(name: str, key: str, sleep: float = 0.0) -> None:
+    module = types.ModuleType(name)
+
+    def process(data, **_settings):
+        if sleep:
+            time.sleep(sleep)
+        return {key: data.get(key, 0) + 1}
+
+    module.process = process
+    sys.modules[name] = module
+
+
+def test_enrichment_runtime():
+    _make_proc("tests.runtime_proc1", "a", sleep=0.05)
+    _make_proc("tests.runtime_proc2", "b", sleep=0.05)
+    kernel = PulseKernel.__new__(PulseKernel)
+    kernel.enrichment_processors = [
+        {"module": "tests.runtime_proc1"},
+        {"module": "tests.runtime_proc2"},
+    ]
+    data = {"a": 0, "b": 1}
+    start = time.perf_counter()
+    result = asyncio.run(kernel._calculate_confluence(data))
+    duration = time.perf_counter() - start
+    assert result == {"a": 1, "b": 2}
+    assert duration < 0.4, f"runtime {duration:.3f}s exceeds 400ms"


### PR DESCRIPTION
## Summary
- Measure total time for enrichment processors and warn if runtime exceeds 0.4s
- Add unit test verifying enrichment processors finish under 400ms

## Testing
- `pytest tests/enrichment/test_runtime.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5465aece48328a71af6eb6cb5d3f0