### PR TITLE
standardize enrichment module entry point

### DIFF
--- a/pulse_kernel.py
+++ b/pulse_kernel.py
@@ -294,12 +294,13 @@ class PulseKernel:
             except Exception as e:
                 logger.warning("Processor %s not available: %s", module_path, e)
                 continue
-            if not hasattr(module, "process"):
-                logger.warning("Processor %s missing process()", module_path)
+            func = getattr(module, "process", getattr(module, "run", None))
+            if func is None:
+                logger.warning("Processor %s missing run()", module_path)
                 continue
             settings = proc.get("settings", {})
             try:
-                result = module.process(data, **settings)
+                result = func(data, **settings)
                 if asyncio.iscoroutine(result):
                     result = await result
             except Exception as e:

--- a/tests/enrichment/test_poi.py
+++ b/tests/enrichment/test_poi.py
@@ -3,27 +3,27 @@ import pandas as pd
 from utils.enrichment import poi
 
 
-def test_process_basic():
+def test_run_basic():
     df = pd.DataFrame({"high": [1.0, 2.0, 3.0], "low": [0.5, 1.0, 2.0]})
-    enriched, vector = poi.process(df)
+    enriched, vector = poi.run(df)
     assert enriched == {"support": 0.5, "resistance": 3.0, "midpoint": 1.75}
     assert vector == [0.5, 3.0, 1.75]
 
 
-def test_process_empty():
-    enriched, vector = poi.process(pd.DataFrame())
+def test_run_empty():
+    enriched, vector = poi.run(pd.DataFrame())
     assert enriched == {}
     assert vector == []
 
 
-def test_process_missing_columns():
+def test_run_missing_columns():
     df = pd.DataFrame({"open": [1, 2, 3]})
-    enriched, vector = poi.process(df)
+    enriched, vector = poi.run(df)
     assert enriched == {}
     assert vector == []
 
 
-def test_process_none():
-    enriched, vector = poi.process(None)
+def test_run_none():
+    enriched, vector = poi.run(None)
     assert enriched == {}
     assert vector == []

--- a/tests/enrichment/test_smc.py
+++ b/tests/enrichment/test_smc.py
@@ -1,9 +1,9 @@
-from utils.enrichment import smc_process
+from utils.enrichment.smc import run
 
 
-def test_smc_process_features_and_vector():
+def test_smc_run_features_and_vector():
     data = {"open": 1.0, "high": 2.0, "low": 0.5, "close": 1.5}
-    features, vector = smc_process(data)
+    features, vector = run(data)
 
     expected_keys = {"range", "midpoint", "body", "is_bullish"}
     assert expected_keys <= features.keys()

--- a/utils/enrichment/__init__.py
+++ b/utils/enrichment/__init__.py
@@ -104,7 +104,8 @@ def enrich_ticks(df: pd.DataFrame) -> pd.DataFrame:
 
     return df
 
-# Expose POI processor
+# Expose selected processors
 from . import poi
+from .rsi import RSIProcessor
 
-__all__ = ["aggregate_ticks_to_bars", "enrich_ticks", "poi"]
+__all__ = ["aggregate_ticks_to_bars", "enrich_ticks", "poi", "RSIProcessor"]

--- a/utils/enrichment/core.py
+++ b/utils/enrichment/core.py
@@ -88,3 +88,12 @@ def enrich_ticks(df: pd.DataFrame) -> pd.DataFrame:
         df["ma_20"] = df["mid_price"].rolling(20).mean()
 
     return df
+
+
+def run(ticks: pd.DataFrame, timeframe: str = "M1") -> pd.DataFrame:
+    """Aggregate ticks then enrich the resulting bars."""
+    bars = aggregate_ticks_to_bars(ticks, timeframe)
+    return enrich_ticks(bars)
+
+
+__all__ = ["aggregate_ticks_to_bars", "enrich_ticks", "run"]

--- a/utils/enrichment/dss.py
+++ b/utils/enrichment/dss.py
@@ -43,5 +43,9 @@ def compute_dss(df: pd.DataFrame) -> Tuple[Dict[str, float], np.ndarray]:
     vector = np.column_stack((displacement, shift)).astype(float)
     return metrics, vector
 
+def run(df: pd.DataFrame) -> Tuple[Dict[str, float], np.ndarray]:
+    """Convenience wrapper around :func:`compute_dss`."""
+    return compute_dss(df)
 
-__all__ = ["compute_dss"]
+
+__all__ = ["compute_dss", "run"]

--- a/utils/enrichment/poi.py
+++ b/utils/enrichment/poi.py
@@ -1,6 +1,6 @@
 """Point‑of‑interest (POI) feature processor.
 
-The :func:`process` function extracts simple support/resistance style
+The :func:`run` function extracts simple support/resistance style
 features from price data and returns both a dictionary of values and a
 vector representation suitable for downstream models.
 """
@@ -28,7 +28,7 @@ def _to_dataframe(data: Any) -> pd.DataFrame:
         return pd.DataFrame()
 
 
-def process(data: Any) -> Tuple[Dict[str, float], List[float]]:
+def run(data: Any) -> Tuple[Dict[str, float], List[float]]:
     """Return basic point‑of‑interest features.
 
     Parameters
@@ -54,3 +54,6 @@ def process(data: Any) -> Tuple[Dict[str, float], List[float]]:
     enriched = {"support": support, "resistance": resistance, "midpoint": midpoint}
     vector = [support, resistance, midpoint]
     return enriched, vector
+
+
+__all__ = ["run"]

--- a/utils/enrichment/rsi.py
+++ b/utils/enrichment/rsi.py
@@ -69,5 +69,16 @@ class RSIProcessor:
         vector = rsi.to_numpy() if return_vector else None
         return enriched, vector
 
+def run(
+    df: pd.DataFrame,
+    period: int = 14,
+    *,
+    column: str = "close",
+    return_vector: bool = False,
+) -> Tuple[pd.DataFrame, Optional[np.ndarray]]:
+    """Convenience function using :class:`RSIProcessor`."""
+    processor = RSIProcessor(period=period)
+    return processor.enrich(df, column=column, return_vector=return_vector)
 
-__all__ = ["RSIProcessor"]
+
+__all__ = ["RSIProcessor", "run"]

--- a/utils/enrichment/smc.py
+++ b/utils/enrichment/smc.py
@@ -1,6 +1,6 @@
 """SMC feature extraction utilities.
 
-The :func:`process` function is intentionally lightweight; it operates on a
+The :func:`run` function is intentionally lightweight; it operates on a
 plain ``dict`` of OHLC values and returns a tuple containing a features
 dictionary and, when possible, a vector representation of those features.
 """
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import Optional
 
 
-def process(data: dict) -> tuple[dict, Optional[list[float]]]:
+def run(data: dict) -> tuple[dict, Optional[list[float]]]:
     """Extract simple SMC features.
 
     Parameters
@@ -56,5 +56,5 @@ def process(data: dict) -> tuple[dict, Optional[list[float]]]:
     return features, vector
 
 
-__all__ = ["process"]
+__all__ = ["run"]
 


### PR DESCRIPTION
## Summary
- support enrichment modules exposing either `process` or `run` in `_calculate_confluence`
- unify enrichment utilities on a `run` entry point and add wrappers where missing
- update enrichment tests to call the new interface

## Testing
- `pytest tests/enrichment/test_smc.py tests/enrichment/test_poi.py tests/enrichment/test_rsi.py tests/enrichment/test_dss.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5465c35dc8328af98daffe725b694