### PR TITLE
feat: configurable journal storage backend

### DIFF
--- a/tests/test_journal_sync.py
+++ b/tests/test_journal_sync.py
@@ -1,0 +1,41 @@
+import json
+import sqlite3
+from types import SimpleNamespace
+
+import core.journal_sync as js
+
+
+def test_write_journal_entry_sqlite(tmp_path, monkeypatch):
+    """Entries should persist to SQLite when configured."""
+
+    db_path = tmp_path / "journal.db"
+    monkeypatch.setenv("JOURNAL_BACKEND", "sqlite")
+    monkeypatch.setenv("JOURNAL_DB_PATH", str(db_path))
+
+    entry = {"ticket": 1, "symbol": "EURUSD"}
+    js.write_journal_entry(entry)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute("SELECT data FROM journal").fetchone()
+    finally:
+        conn.close()
+    assert json.loads(row[0]) == entry
+
+
+def test_write_journal_entry_redis_errors_handled(monkeypatch):
+    """Redis backend errors should not propagate."""
+
+    monkeypatch.setenv("JOURNAL_BACKEND", "redis")
+
+    class DummyClient:
+        def xadd(self, *a, **k):  # pragma: no cover - executed
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        js, "redis", SimpleNamespace(from_url=lambda *a, **k: DummyClient())
+    )
+
+    # Should not raise despite the xadd failure
+    js.write_journal_entry({"ticket": 2})
+


### PR DESCRIPTION
## Summary
- implement `write_journal_entry` to persist journal entries to Redis or SQLite based on `JOURNAL_BACKEND`
- add logging and graceful error handling for storage failures
- cover new functionality with tests for both backends

## Testing
- `pytest tests/test_journal_sync.py`
- `pre-commit run --files core/journal_sync.py tests/test_journal_sync.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c545667c2c8328a22b7f3e950ec412