### PR TITLE
Log exceptions in daily profit check

### DIFF
--- a/tests/test_risk_enforcer_profit_target_errors.py
+++ b/tests/test_risk_enforcer_profit_target_errors.py
@@ -1,0 +1,35 @@
+import logging
+import pytest
+
+from risk_enforcer import EnhancedRiskEnforcer
+
+
+def _build_enforcer():
+    enforcer = EnhancedRiskEnforcer()
+    # Mirror core state for direct method access
+    enforcer.limits = enforcer.core.limits
+    enforcer.daily_stats = enforcer.core.daily_stats
+    enforcer.behavioral_flags = enforcer.core.behavioral_flags
+    enforcer.state = enforcer.core.state
+    return enforcer
+
+
+def test_check_daily_profit_target_logs_and_raises(caplog):
+    enforcer = _build_enforcer()
+    enforcer.limits["daily_profit_target_usd"] = 100
+    enforcer.daily_stats["total_pnl"] = "bad"  # force float conversion error
+    with caplog.at_level(logging.ERROR, logger="risk_enforcer"):
+        with pytest.raises(Exception):
+            enforcer._check_daily_profit_target()
+    assert "Daily profit target check failed" in caplog.text
+
+
+def test_allow_surfaces_profit_target_exception(caplog):
+    enforcer = _build_enforcer()
+    enforcer.limits["daily_profit_target_usd"] = 100
+    enforcer.daily_stats["total_pnl"] = "bad"
+    signal = {"sod_equity": 1000}
+    with caplog.at_level(logging.ERROR, logger="risk_enforcer"):
+        with pytest.raises(Exception):
+            enforcer.allow(signal)
+    assert "Daily profit target check failed" in caplog.text


### PR DESCRIPTION
## Summary
- add logging and re-raise errors in `_check_daily_profit_target`
- cover daily profit target error handling in tests

## Testing
- `pytest tests/test_risk_enforcer_profit_target_errors.py tests/test_risk_enforcer_imports.py -q`
- `pytest tests/test_risk_enforcer_profit_target_errors.py tests/test_pulse_integration.py::test_risk_enforcer tests/test_risk_enforcer_imports.py -q` *(fails: SyntaxError: invalid character '\u2011' in core/semantic_mapping_service.py)*

------
https://chatgpt.com/codex/tasks/task_b_68c5456a7bac8328a52240273f61dd83