### PR TITLE
chore: remove duplicate confluent kafka import

### DIFF
--- a/ops/kafka/replay_consumer.py
+++ b/ops/kafka/replay_consumer.py
@@ -48,8 +48,6 @@ import os
 from typing import Iterable, Optional
 
 import pyarrow as pa
-
-from confluent_kafka import Consumer, KafkaError, TopicPartition
 try:  # pragma: no cover - module may be absent in tests
     from confluent_kafka import Consumer, KafkaError, TopicPartition
 except Exception:  # pragma: no cover - fallback for environments without kafka


### PR DESCRIPTION
## Summary
- remove duplicated confluent_kafka import from replay_consumer and rely on try/except for graceful fallback

## Testing
- `pytest` *(fails: RuntimeError populate() isn't reentrant)*

------
https://chatgpt.com/codex/tasks/task_b_68c5520d3e9c8328b6695e53cfedb396