### PR TITLE
feat: add deal behavior flag detection

### DIFF
--- a/tests/test_journal_sync.py
+++ b/tests/test_journal_sync.py
@@ -39,3 +39,25 @@ def test_write_journal_entry_redis_errors_handled(monkeypatch):
     # Should not raise despite the xadd failure
     js.write_journal_entry({"ticket": 2})
 
+
+def test_detect_behavior_flags_excessive_volume():
+    """Large trade volume should trigger an EXCESSIVE_VOLUME flag."""
+
+    js._LAST_DEAL_BY_SYMBOL.clear()
+    deal = SimpleNamespace(symbol="EURUSD", type=0, time=100, volume=10)
+    flags = js.detect_behavior_flags(deal)
+    assert "EXCESSIVE_VOLUME" in flags
+
+
+def test_detect_behavior_flags_rapid_flip():
+    """Opposite trades within the rapid flip window should be flagged."""
+
+    js._LAST_DEAL_BY_SYMBOL.clear()
+    first = SimpleNamespace(symbol="EURUSD", type=0, time=100, volume=1)
+    second = SimpleNamespace(symbol="EURUSD", type=1, time=120, volume=1)
+
+    js.detect_behavior_flags(first)
+    flags = js.detect_behavior_flags(second)
+
+    assert "RAPID_FLIP" in flags
+


### PR DESCRIPTION
## Summary
- detect excessive volume and rapid flips from MT5 deals
- track previous deal per symbol to flag rapid flips
- test behavior flag detection and journal entry persistence

## Testing
- `pytest tests/test_journal_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5520cba0c8328bd7e48779c559e96